### PR TITLE
Restart `load_all()` instead of patching load order

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -16,7 +16,6 @@ Suggests:
     pkgload (>= 1.4.0.9000),
     testthat (>= 3.0.0),
     rlang,
+    cli,
     bench
 Config/testthat/edition: 3
-Remotes: 
-    t-kalinowski/pkgload@load_code-then-compile_dll

--- a/R/quick.R
+++ b/R/quick.R
@@ -1,6 +1,3 @@
-
-
-
 #' Quick Function
 #'
 #' @param fun An R function
@@ -17,14 +14,15 @@ quick <- function(fun, name = NULL) {
   }
 
   if (nzchar(pkgname <- Sys.getenv("DEVTOOLS_LOAD"))) {
-    if (requireNamespace("pkgload", quietly = TRUE)) {
-      if (!collector$is_active()) {
-        for (i in seq_along(sys.calls())) {
-          if (identical(sys.function(i), pkgload::load_code)) {
-            collector$activate(paste0(pkgname, ":quick_funcs"))
-            defer(dump_collected(), sys.frame(i))
-            break
-          }
+    if (!collector$is_active()) {
+      if (!requireNamespace("pkgload", quietly = TRUE)) {
+        stop("Please install 'pkgload'")
+      }
+      for (i in seq_along(sys.calls())) {
+        if (identical(sys.function(i), pkgload::load_code)) {
+          collector$activate(paste0(pkgname, ":quick_funcs"))
+          defer(dump_collected(), sys.frame(i), after = TRUE)
+          break
         }
       }
     }


### PR DESCRIPTION
This removes the requirement for a patched version of `pkgload` and ensures that `quickr` works with the current CRAN release of `pkgload` and `devtools`.

This is the last blocker before the CRAN release.
