### PR TITLE
Print `c_bridge` from `r2f(<func>)`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # quickr (development version)
 
+- Internal utility `r2f()` print method now shows the generated `c_bridge` 
+  for translated subroutines.
+
 - Added support for `while`, `repeat`, `break`, `next`.
 
 - Added support for `%%` and `%/%`.

--- a/R/classes.R
+++ b/R/classes.R
@@ -282,10 +282,17 @@ FortranSubroutine := new_class(Fortran, properties = list(
   name = prop_string(),
   signature = class_character,
   closure = class_function,
-  scope = NULL | class_environment
+  scope = NULL | class_environment,
+  c_bridge = S7::new_property(
+    NULL | class_character,
+    getter = function(self) {
+      make_c_bridge(self) %error% NULL
+    })
 ))
 
+`%error%` <- function(x, y) tryCatch(x, error = function(e) y)
 
+try_prop <- function(object, name) S7::prop(object, name) %error% NULL
 
 emit <- function(..., sep = "", end = "\n") cat(..., end, sep = sep)
 
@@ -297,25 +304,9 @@ method(as.character, Variable) <- function(x, ...)
   x@name %||% stop("Variable does not have a name")
 
 method(print, Fortran) <- function(x, ...) {
-  # cat("Fortran:\n", x, "\n", sep = "")
   emit(trimws(x), end = "\n\n")
-  for(prop_name in c("value", "r"))
-    if (!is.null(prop_val <- prop(x, prop_name))) {
-      emit("@", prop_name, ": ", trimws(indent(format(prop_val))));
-      # str(prop_val, nest.lev = 1)
-    }
-
-
-  # cat("@r:\n")
-  # print(x@r)
-}
-
-method(print, FortranSubroutine) <- function(x, ...) {
-  NextMethod()
-  for(prop_name in  c("closure")) # c("signature",
-    if (!is.null(prop_val <- prop(x, prop_name))) {
+  for(prop_name in c("value", "r", "c_bridge"))
+    if (!is.null(prop_val <- try_prop(x, prop_name))) {
       emit("@", prop_name, ": ", trimws(indent(format(prop_val))));
     }
-  # getS3method("str", "S7_object")(x)
 }
-

--- a/tests/testthat/_snaps/r2f.md
+++ b/tests/testthat/_snaps/r2f.md
@@ -264,11 +264,34 @@
             out <- which.max(a)
             out
         }
-      @closure: function (a)
-        {
-            declare(type(a = double(NA)))
-            out <- which.max(a)
-            out
+      @c_bridge: #define R_NO_REMAP
+        #include <R.h>
+        #include <Rinternals.h>
+        
+        
+        extern void fn(
+          const double* const a__,
+          int* const out__,
+          const R_len_t a__len_);
+        
+        SEXP fn_(SEXP _args) {
+          // a
+          _args = CDR(_args);
+          SEXP a = CAR(_args);
+          if (TYPEOF(a) != REALSXP) {
+            Rf_error("typeof(a) must be 'double', not '%s'", R_typeToChar(a));
+          }
+          const double* const a__ = REAL(a);
+          const R_xlen_t a__len_ = Rf_xlength(a);
+        
+          const R_xlen_t out__len_ = (1);
+          SEXP out = PROTECT(Rf_allocVector(INTSXP, out__len_));
+          int* out__ = INTEGER(out);
+        
+          fn(a__, out__, a__len_);
+        
+          UNPROTECT(1);
+          return out;
         }
 
 ---
@@ -299,11 +322,34 @@
             out <- which.max(a)
             out
         }
-      @closure: function (a)
-        {
-            declare(type(a = logical(NA)))
-            out <- which.max(a)
-            out
+      @c_bridge: #define R_NO_REMAP
+        #include <R.h>
+        #include <Rinternals.h>
+        
+        
+        extern void fn(
+          const int* const a__,
+          int* const out__,
+          const R_len_t a__len_);
+        
+        SEXP fn_(SEXP _args) {
+          // a
+          _args = CDR(_args);
+          SEXP a = CAR(_args);
+          if (TYPEOF(a) != LGLSXP) {
+            Rf_error("typeof(a) must be 'logical', not '%s'", R_typeToChar(a));
+          }
+          const int* const a__ = LOGICAL(a);
+          const R_xlen_t a__len_ = Rf_xlength(a);
+        
+          const R_xlen_t out__len_ = (1);
+          SEXP out = PROTECT(Rf_allocVector(INTSXP, out__len_));
+          int* out__ = INTEGER(out);
+        
+          fn(a__, out__, a__len_);
+        
+          UNPROTECT(1);
+          return out;
         }
 
 # matrix
@@ -334,12 +380,56 @@
             out <- matrix(0, a, b)
             out
         }
-      @closure: function (a, b)
-        {
-            declare(type(a = integer(1)))
-            declare(type(b = integer(1)))
-            out <- matrix(0, a, b)
-            out
+      @c_bridge: #define R_NO_REMAP
+        #include <R.h>
+        #include <Rinternals.h>
+        
+        
+        extern void fn(
+          const int* const a__,
+          const int* const b__,
+          double* const out__);
+        
+        SEXP fn_(SEXP _args) {
+          // a
+          _args = CDR(_args);
+          SEXP a = CAR(_args);
+          if (TYPEOF(a) != INTSXP) {
+            Rf_error("typeof(a) must be 'integer', not '%s'", R_typeToChar(a));
+          }
+          const int* const a__ = INTEGER(a);
+          const R_xlen_t a__len_ = Rf_xlength(a);
+        
+          // b
+          _args = CDR(_args);
+          SEXP b = CAR(_args);
+          if (TYPEOF(b) != INTSXP) {
+            Rf_error("typeof(b) must be 'integer', not '%s'", R_typeToChar(b));
+          }
+          const int* const b__ = INTEGER(b);
+          const R_xlen_t b__len_ = Rf_xlength(b);
+        
+          if (a__len_ != 1)
+            Rf_error("length(a) must be 1, not %0.f",
+                      (double)a__len_);
+          if (b__len_ != 1)
+            Rf_error("length(b) must be 1, not %0.f",
+                      (double)b__len_);
+          const R_xlen_t out__len_ = (Rf_asInteger(a)) * (Rf_asInteger(b));
+          SEXP out = PROTECT(Rf_allocVector(REALSXP, out__len_));
+          double* out__ = REAL(out);
+          {
+            const SEXP _dim_sexp = PROTECT(Rf_allocVector(INTSXP, 2));
+            int* const _dim = INTEGER(_dim_sexp);
+            _dim[0] = Rf_asInteger(a);
+            _dim[1] = Rf_asInteger(b);
+            Rf_dimgets(out, _dim_sexp);
+          }
+        
+          fn(a__, b__, out__);
+        
+          UNPROTECT(2);
+          return out;
         }
 
 # reuse implicit size
@@ -373,12 +463,63 @@
             out <- a1 + a2[1, ]
             out
         }
-      @closure: function (a1, a2)
-        {
-            declare(type(a1 = double(n)))
-            declare(type(a2 = double(n, n)))
-            out <- a1 + a2[1, ]
-            out
+      @c_bridge: #define R_NO_REMAP
+        #include <R.h>
+        #include <Rinternals.h>
+        
+        
+        extern void fn(
+          const double* const a1__,
+          const double* const a2__,
+          double* const out__,
+          const R_len_t a1__len_);
+        
+        SEXP fn_(SEXP _args) {
+          // a1
+          _args = CDR(_args);
+          SEXP a1 = CAR(_args);
+          if (TYPEOF(a1) != REALSXP) {
+            Rf_error("typeof(a1) must be 'double', not '%s'", R_typeToChar(a1));
+          }
+          const double* const a1__ = REAL(a1);
+          const R_xlen_t a1__len_ = Rf_xlength(a1);
+        
+          // a2
+          _args = CDR(_args);
+          SEXP a2 = CAR(_args);
+          if (TYPEOF(a2) != REALSXP) {
+            Rf_error("typeof(a2) must be 'double', not '%s'", R_typeToChar(a2));
+          }
+          const double* const a2__ = REAL(a2);
+          const int* const a2__dim_ = ({
+          SEXP dim_ = Rf_getAttrib(a2, R_DimSymbol);
+          if (Rf_length(dim_) != 2) Rf_error(
+            "a2 must be a 2D-array, but length(dim(a2)) is %i",
+            (int) Rf_length(dim_));
+          INTEGER(dim_);});
+          const int a2__dim_1_ = a2__dim_[0];
+          const int a2__dim_2_ = a2__dim_[1];
+        
+          if (a1__len_ != a2__dim_1_)
+            Rf_error("dim(a2)[1] must equal length(a1),"
+                     " but are %0.f and %0.f",
+                      (double)a2__dim_1_, (double)a1__len_);
+          if (a1__len_ != a2__dim_2_)
+            Rf_error("dim(a2)[2] must equal length(a1),"
+                     " but are %0.f and %0.f",
+                      (double)a2__dim_2_, (double)a1__len_);
+          const R_xlen_t out__len_ = a1__len_;
+          SEXP out = PROTECT(Rf_allocVector(REALSXP, out__len_));
+          double* out__ = REAL(out);
+        
+          fn(
+            a1__,
+            a2__,
+            out__,
+            a1__len_);
+        
+          UNPROTECT(1);
+          return out;
         }
     Code
       cat(c_wrapper)


### PR DESCRIPTION
The print method for `FortranSubroutine` (returned by `quickr:::r2f(<r-func>)`) now also displays the generated C function that invokes the Fortran subroutine from R. This can help diagnose where and when allocations are made, or for general exploration and understanding.
