### PR TITLE
Add test for dynamic Fortran dims

### DIFF
--- a/R/manifest.R
+++ b/R/manifest.R
@@ -153,7 +153,7 @@ dims2f <- function(dims, scope) {
   syms <- unique(unlist(lapply(dims, \(d) if (is.language(d)) all.vars(d))))
   vars <- as.list(syms)
   names(vars) <- syms
-  eval_env <- list2env(vars, parent = dims2c_eval_base_env)
+  eval_env <- list2env(vars, parent = dims2f_eval_base_env)
   dims <- map_chr(dims, function(d) {
     d <- eval(d, eval_env)
     if (is.symbol(d)) as.character(d)

--- a/tests/testthat/test-dims2f.R
+++ b/tests/testthat/test-dims2f.R
@@ -1,0 +1,39 @@
+
+# Tests for dynamic dimension expressions evaluated in Fortran environment
+
+test_that("arithmetic expressions in dimensions compile", {
+  fn <- function(n) {
+    declare(type(n = integer(1)))
+    x <- double(n * 2L)
+    y <- double(n - 1L)
+    length(x) + length(y)
+  }
+  qfn <- quick(fn)
+  expect_identical(qfn(4L), fn(4L))
+  expect_identical(qfn(7L), fn(7L))
+})
+
+
+test_that("integer division and modulus in dimensions compile", {
+  fn <- function(n) {
+    declare(type(n = integer(1)))
+    out <- double(n %/% 2L + n %% 2L)
+    length(out)
+  }
+  qfn <- quick(fn)
+  expect_identical(qfn(5L), fn(5L))
+  expect_identical(qfn(8L), fn(8L))
+})
+
+
+test_that("matrix dimension expressions compile", {
+  fn <- function(n) {
+    declare(type(n = integer(1)))
+    out <- matrix(1, n + 1L, n %/% 2L + 1L)
+    dim(out)
+  }
+  qfn <- quick(fn)
+  expect_identical(qfn(3L), fn(3L))
+  expect_identical(qfn(6L), fn(6L))
+})
+


### PR DESCRIPTION
## Summary
- use the Fortran evaluation environment in `dims2f`
- exercise `dims2f` with dynamic dimension expressions

## Testing
- `R -q -e "testthat::test_local()"`

------
https://chatgpt.com/codex/tasks/task_e_68803bbc9e4c8332a994ba9350c1c001