### PR TITLE
Add support for `runif()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,9 +1,11 @@
 # quickr (development version)
 
-- Internal utility `r2f()` print method now shows the generated `c_bridge` 
+- Internal utility `r2f()` print method now shows the generated `c_bridge`
   for translated subroutines.
-  
+
 - Added support for `nrow()`, `ncol()` and `dim()` (#21, @mikmart).
+
+- Added support for `runif()` with integration to R's RNG (#22, #45).
 
 - Added support for `while`, `repeat`, `break`, `next`.
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -24,6 +24,8 @@
 
 - Fixed segfault encountered on Windows with variable sized arrays.
 
+- Added workaround for cases where the compiler error message might not
+  display correctly in RStudio.
 
 # quickr 0.1.0
 

--- a/R/c-wrapper.R
+++ b/R/c-wrapper.R
@@ -81,6 +81,7 @@ make_c_bridge <- function(fsub, strict = TRUE, headers = TRUE) {
     "#include <R.h>",
     "#include <Rinternals.h>",
     if (uses_rng) "#include <R_ext/Random.h>",
+    "",
     ""
   )
 

--- a/R/quick.R
+++ b/R/quick.R
@@ -187,6 +187,9 @@ compile <- function(fsub, build_dir = tempfile(paste0(fsub@name, "-build-"))) {
   if (!is.null(attr(result, "status"))) {
     writeLines(result, stderr())
     str(attributes(result))
+    cat("\n----\n") # https://github.com/rstudio/rstudio/issues/16365
+    flush.connection(stderr())
+    flush.console()
     stop("Compilation Error")
   }
 

--- a/R/quick.R
+++ b/R/quick.R
@@ -184,13 +184,13 @@ compile <- function(fsub, build_dir = tempfile(paste0(fsub@name, "-build-"))) {
       stderr = TRUE
     )
   })
-  if (!is.null(attr(result, "status"))) {
+  if (!is.null(status <- attr(result, "status"))) {
+    # Adjust the compiler error so RStudio console formatter doesn't mangle
+    # the actual error message https://github.com/rstudio/rstudio/issues/16365
+    result <- gsub("Error: ", "Compiler Error: ", result, fixed = TRUE)
     writeLines(result, stderr())
-    str(attributes(result))
-    cat("\n----\n") # https://github.com/rstudio/rstudio/issues/16365
-    flush.connection(stderr())
-    flush.console()
-    stop("Compilation Error")
+    cat("---\nCompiler exit status:", status, "\n", file = stderr())
+    stop("Compilation Error", call. = FALSE)
   }
 
   # tryCatch(dyn.unload(dll_path), error = identity)

--- a/R/r2f.R
+++ b/R/r2f.R
@@ -944,6 +944,39 @@ r2f_handlers[["double"]] <- function(args, scope, ...) {
 
 r2f_handlers[["numeric"]] <- r2f_handlers[["double"]]
 
+r2f_handlers[["runif"]] <- function(args, scope, ..., hoist = NULL) {
+  attr(scope, "uses_rng") <- TRUE
+
+  dims <- r2dims(args$n, scope)
+  var <- Variable("double", dims)
+
+  min <- args$min %||% 0
+  max <- args$max %||% 1
+  default_min <- identical(min, 0) || identical(min, 0L)
+  default_max <- identical(max, 1) || identical(max, 1L)
+
+  if (default_min && default_max) {
+    get1rand <- "unif_rand()"
+  } else if (default_min) {
+    max <- r2f(max, scope, ..., hoist = hoist)
+    get1rand <- glue("unif_rand() * {max}")
+  } else {
+    max <- r2f(max, scope, ..., hoist = hoist)
+    min <- r2f(min, scope, ..., hoist = hoist)
+    get1rand <- glue("({min} + (unif_rand() * ({max} - {min})))")
+  }
+
+  if (passes_as_scalar(var)) {
+    fortran <- get1rand
+  } else {
+    tmp_i <- scope@get_unique_var("integer") ## would be better as uint64...
+    fortran <- glue("[({get1rand}, {tmp_i}=1, {dims[[1L]]})]")
+  }
+
+  Fortran(fortran, var)
+}
+
+
 r2f_handlers[["character"]] <- r2f_handlers[["raw"]] <-
   .r2f_handler_not_implemented_yet
 

--- a/tests/testthat/_snaps/runif.md
+++ b/tests/testthat/_snaps/runif.md
@@ -1,0 +1,565 @@
+# runif generates random numbers
+
+    Code
+      fn
+    Output
+      function(n) {
+          declare(type(n = integer(1)))
+          runif(n)
+        }
+      <environment: 0x0>
+    Code
+      cat(fsub)
+    Output
+      subroutine fn(n, out_) bind(c)
+        use iso_c_binding, only: c_double, c_int
+        implicit none
+      
+        ! manifest start
+        ! args
+        integer(c_int), intent(in) :: n
+        real(c_double), intent(out) :: out_(n)
+      
+        ! locals
+        integer(c_int) :: tmp1_
+        ! manifest end
+      
+        interface
+          function unif_rand() bind(c, name = "unif_rand") result(u)
+            use iso_c_binding, only: c_double
+            real(c_double) :: u
+          end function unif_rand
+        end interface
+      
+      
+        out_ = [(unif_rand(), tmp1_=1, n)]
+      end subroutine
+    Code
+      cat(cwrapper)
+    Output
+      #define R_NO_REMAP
+      #include <R.h>
+      #include <Rinternals.h>
+      #include <R_ext/Random.h>
+      
+      
+      extern void fn(const int* const n__, double* const out___);
+      
+      SEXP fn_(SEXP _args) {
+        // n
+        _args = CDR(_args);
+        SEXP n = CAR(_args);
+        if (TYPEOF(n) != INTSXP) {
+          Rf_error("typeof(n) must be 'integer', not '%s'", R_typeToChar(n));
+        }
+        const int* const n__ = INTEGER(n);
+        const R_xlen_t n__len_ = Rf_xlength(n);
+        
+        if (n__len_ != 1)
+          Rf_error("length(n) must be 1, not %0.f",
+                    (double)n__len_);
+        const R_xlen_t out___len_ = Rf_asInteger(n);
+        SEXP out_ = PROTECT(Rf_allocVector(REALSXP, out___len_));
+        double* out___ = REAL(out_);
+        
+        GetRNGstate();
+        fn(n__, out___);
+        PutRNGstate();
+        
+        UNPROTECT(1);
+        return out_;
+      }
+
+---
+
+    Code
+      fn
+    Output
+      function(x) {
+          declare(type(x = double(NA)))
+          x * runif(1)
+        }
+      <environment: 0x0>
+    Code
+      cat(fsub)
+    Output
+      subroutine fn(x, out_, x__len_) bind(c)
+        use iso_c_binding, only: c_double, c_ptrdiff_t
+        implicit none
+      
+        ! manifest start
+        ! sizes
+        integer(c_ptrdiff_t), intent(in), value :: x__len_
+      
+        ! args
+        real(c_double), intent(in) :: x(x__len_)
+        real(c_double), intent(out) :: out_(x__len_)
+        ! manifest end
+      
+        interface
+          function unif_rand() bind(c, name = "unif_rand") result(u)
+            use iso_c_binding, only: c_double
+            real(c_double) :: u
+          end function unif_rand
+        end interface
+      
+      
+        out_ = (x * unif_rand())
+      end subroutine
+    Code
+      cat(cwrapper)
+    Output
+      #define R_NO_REMAP
+      #include <R.h>
+      #include <Rinternals.h>
+      #include <R_ext/Random.h>
+      
+      
+      extern void fn(
+        const double* const x__, 
+        double* const out___, 
+        const R_xlen_t x__len_);
+      
+      SEXP fn_(SEXP _args) {
+        // x
+        _args = CDR(_args);
+        SEXP x = CAR(_args);
+        if (TYPEOF(x) != REALSXP) {
+          Rf_error("typeof(x) must be 'double', not '%s'", R_typeToChar(x));
+        }
+        const double* const x__ = REAL(x);
+        const R_xlen_t x__len_ = Rf_xlength(x);
+        
+        const R_xlen_t out___len_ = x__len_;
+        SEXP out_ = PROTECT(Rf_allocVector(REALSXP, out___len_));
+        double* out___ = REAL(out_);
+        
+        GetRNGstate();
+        fn(x__, out___, x__len_);
+        PutRNGstate();
+        
+        UNPROTECT(1);
+        return out_;
+      }
+
+---
+
+    Code
+      fn
+    Output
+      function(x) {
+          declare(type(x = double(NA)))
+          x * runif(length(x))
+        }
+      <environment: 0x0>
+    Code
+      cat(fsub)
+    Output
+      subroutine fn(x, out_, x__len_) bind(c)
+        use iso_c_binding, only: c_double, c_int, c_ptrdiff_t
+        implicit none
+      
+        ! manifest start
+        ! sizes
+        integer(c_ptrdiff_t), intent(in), value :: x__len_
+      
+        ! args
+        real(c_double), intent(in) :: x(x__len_)
+        real(c_double), intent(out) :: out_(x__len_)
+      
+        ! locals
+        integer(c_int) :: tmp1_
+        ! manifest end
+      
+        interface
+          function unif_rand() bind(c, name = "unif_rand") result(u)
+            use iso_c_binding, only: c_double
+            real(c_double) :: u
+          end function unif_rand
+        end interface
+      
+      
+        out_ = (x * [(unif_rand(), tmp1_=1, x__len_)])
+      end subroutine
+    Code
+      cat(cwrapper)
+    Output
+      #define R_NO_REMAP
+      #include <R.h>
+      #include <Rinternals.h>
+      #include <R_ext/Random.h>
+      
+      
+      extern void fn(
+        const double* const x__, 
+        double* const out___, 
+        const R_xlen_t x__len_);
+      
+      SEXP fn_(SEXP _args) {
+        // x
+        _args = CDR(_args);
+        SEXP x = CAR(_args);
+        if (TYPEOF(x) != REALSXP) {
+          Rf_error("typeof(x) must be 'double', not '%s'", R_typeToChar(x));
+        }
+        const double* const x__ = REAL(x);
+        const R_xlen_t x__len_ = Rf_xlength(x);
+        
+        const R_xlen_t out___len_ = x__len_;
+        SEXP out_ = PROTECT(Rf_allocVector(REALSXP, out___len_));
+        double* out___ = REAL(out_);
+        
+        GetRNGstate();
+        fn(x__, out___, x__len_);
+        PutRNGstate();
+        
+        UNPROTECT(1);
+        return out_;
+      }
+
+# runif with min/max
+
+    Code
+      fn
+    Output
+      function(n, a, b) {
+          declare(
+            type(n = integer(1)),
+            type(a = double(1)),
+            type(b = double(1))
+          )
+          runif(n, a, b)
+        }
+      <environment: 0x0>
+    Code
+      cat(fsub)
+    Output
+      subroutine fn(n, a, b, out_) bind(c)
+        use iso_c_binding, only: c_double, c_int
+        implicit none
+      
+        ! manifest start
+        ! args
+        integer(c_int), intent(in) :: n
+        real(c_double), intent(in) :: a
+        real(c_double), intent(in) :: b
+        real(c_double), intent(out) :: out_(n)
+      
+        ! locals
+        integer(c_int) :: tmp1_
+        ! manifest end
+      
+        interface
+          function unif_rand() bind(c, name = "unif_rand") result(u)
+            use iso_c_binding, only: c_double
+            real(c_double) :: u
+          end function unif_rand
+        end interface
+      
+      
+        out_ = [((a + (unif_rand() * (b - a))), tmp1_=1, n)]
+      end subroutine
+    Code
+      cat(cwrapper)
+    Output
+      #define R_NO_REMAP
+      #include <R.h>
+      #include <Rinternals.h>
+      #include <R_ext/Random.h>
+      
+      
+      extern void fn(
+        const int* const n__, 
+        const double* const a__, 
+        const double* const b__, 
+        double* const out___);
+      
+      SEXP fn_(SEXP _args) {
+        // n
+        _args = CDR(_args);
+        SEXP n = CAR(_args);
+        if (TYPEOF(n) != INTSXP) {
+          Rf_error("typeof(n) must be 'integer', not '%s'", R_typeToChar(n));
+        }
+        const int* const n__ = INTEGER(n);
+        const R_xlen_t n__len_ = Rf_xlength(n);
+        
+        // a
+        _args = CDR(_args);
+        SEXP a = CAR(_args);
+        if (TYPEOF(a) != REALSXP) {
+          Rf_error("typeof(a) must be 'double', not '%s'", R_typeToChar(a));
+        }
+        const double* const a__ = REAL(a);
+        const R_xlen_t a__len_ = Rf_xlength(a);
+        
+        // b
+        _args = CDR(_args);
+        SEXP b = CAR(_args);
+        if (TYPEOF(b) != REALSXP) {
+          Rf_error("typeof(b) must be 'double', not '%s'", R_typeToChar(b));
+        }
+        const double* const b__ = REAL(b);
+        const R_xlen_t b__len_ = Rf_xlength(b);
+        
+        if (n__len_ != 1)
+          Rf_error("length(n) must be 1, not %0.f",
+                    (double)n__len_);
+        if (a__len_ != 1)
+          Rf_error("length(a) must be 1, not %0.f",
+                    (double)a__len_);
+        if (b__len_ != 1)
+          Rf_error("length(b) must be 1, not %0.f",
+                    (double)b__len_);
+        const R_xlen_t out___len_ = Rf_asInteger(n);
+        SEXP out_ = PROTECT(Rf_allocVector(REALSXP, out___len_));
+        double* out___ = REAL(out_);
+        
+        GetRNGstate();
+        fn(
+          n__,
+          a__,
+          b__,
+          out___);
+        PutRNGstate();
+        
+        UNPROTECT(1);
+        return out_;
+      }
+
+---
+
+    Code
+      fn
+    Output
+      function(n, b) {
+          declare(
+            type(n = integer(1)),
+            type(b = double(1))
+          )
+          runif(n, max = b)
+        }
+      <environment: 0x0>
+    Code
+      cat(fsub)
+    Output
+      subroutine fn(n, b, out_) bind(c)
+        use iso_c_binding, only: c_double, c_int
+        implicit none
+      
+        ! manifest start
+        ! args
+        integer(c_int), intent(in) :: n
+        real(c_double), intent(in) :: b
+        real(c_double), intent(out) :: out_(n)
+      
+        ! locals
+        integer(c_int) :: tmp1_
+        ! manifest end
+      
+        interface
+          function unif_rand() bind(c, name = "unif_rand") result(u)
+            use iso_c_binding, only: c_double
+            real(c_double) :: u
+          end function unif_rand
+        end interface
+      
+      
+        out_ = [(unif_rand() * b, tmp1_=1, n)]
+      end subroutine
+    Code
+      cat(cwrapper)
+    Output
+      #define R_NO_REMAP
+      #include <R.h>
+      #include <Rinternals.h>
+      #include <R_ext/Random.h>
+      
+      
+      extern void fn(
+        const int* const n__, 
+        const double* const b__, 
+        double* const out___);
+      
+      SEXP fn_(SEXP _args) {
+        // n
+        _args = CDR(_args);
+        SEXP n = CAR(_args);
+        if (TYPEOF(n) != INTSXP) {
+          Rf_error("typeof(n) must be 'integer', not '%s'", R_typeToChar(n));
+        }
+        const int* const n__ = INTEGER(n);
+        const R_xlen_t n__len_ = Rf_xlength(n);
+        
+        // b
+        _args = CDR(_args);
+        SEXP b = CAR(_args);
+        if (TYPEOF(b) != REALSXP) {
+          Rf_error("typeof(b) must be 'double', not '%s'", R_typeToChar(b));
+        }
+        const double* const b__ = REAL(b);
+        const R_xlen_t b__len_ = Rf_xlength(b);
+        
+        if (n__len_ != 1)
+          Rf_error("length(n) must be 1, not %0.f",
+                    (double)n__len_);
+        if (b__len_ != 1)
+          Rf_error("length(b) must be 1, not %0.f",
+                    (double)b__len_);
+        const R_xlen_t out___len_ = Rf_asInteger(n);
+        SEXP out_ = PROTECT(Rf_allocVector(REALSXP, out___len_));
+        double* out___ = REAL(out_);
+        
+        GetRNGstate();
+        fn(n__, b__, out___);
+        PutRNGstate();
+        
+        UNPROTECT(1);
+        return out_;
+      }
+
+---
+
+    Code
+      fn
+    Output
+      function(b) {
+          declare(
+            type(b = double(1))
+          )
+          runif(1, max = b)
+        }
+      <environment: 0x0>
+    Code
+      cat(fsub)
+    Output
+      subroutine fn(b, out_) bind(c)
+        use iso_c_binding, only: c_double
+        implicit none
+      
+        ! manifest start
+        ! args
+        real(c_double), intent(in) :: b
+        real(c_double), intent(out) :: out_
+        ! manifest end
+      
+        interface
+          function unif_rand() bind(c, name = "unif_rand") result(u)
+            use iso_c_binding, only: c_double
+            real(c_double) :: u
+          end function unif_rand
+        end interface
+      
+      
+        out_ = unif_rand() * b
+      end subroutine
+    Code
+      cat(cwrapper)
+    Output
+      #define R_NO_REMAP
+      #include <R.h>
+      #include <Rinternals.h>
+      #include <R_ext/Random.h>
+      
+      
+      extern void fn(const double* const b__, double* const out___);
+      
+      SEXP fn_(SEXP _args) {
+        // b
+        _args = CDR(_args);
+        SEXP b = CAR(_args);
+        if (TYPEOF(b) != REALSXP) {
+          Rf_error("typeof(b) must be 'double', not '%s'", R_typeToChar(b));
+        }
+        const double* const b__ = REAL(b);
+        const R_xlen_t b__len_ = Rf_xlength(b);
+        
+        if (b__len_ != 1)
+          Rf_error("length(b) must be 1, not %0.f",
+                    (double)b__len_);
+        const R_xlen_t out___len_ = (1);
+        SEXP out_ = PROTECT(Rf_allocVector(REALSXP, out___len_));
+        double* out___ = REAL(out_);
+        
+        GetRNGstate();
+        fn(b__, out___);
+        PutRNGstate();
+        
+        UNPROTECT(1);
+        return out_;
+      }
+
+---
+
+    Code
+      fn
+    Output
+      function(b) {
+          declare(
+            type(b = double(1))
+          )
+          runif(10, max = b)
+        }
+      <environment: 0x0>
+    Code
+      cat(fsub)
+    Output
+      subroutine fn(b, out_) bind(c)
+        use iso_c_binding, only: c_double, c_int
+        implicit none
+      
+        ! manifest start
+        ! args
+        real(c_double), intent(in) :: b
+        real(c_double), intent(out) :: out_(10)
+      
+        ! locals
+        integer(c_int) :: tmp1_
+        ! manifest end
+      
+        interface
+          function unif_rand() bind(c, name = "unif_rand") result(u)
+            use iso_c_binding, only: c_double
+            real(c_double) :: u
+          end function unif_rand
+        end interface
+      
+      
+        out_ = [(unif_rand() * b, tmp1_=1, 10)]
+      end subroutine
+    Code
+      cat(cwrapper)
+    Output
+      #define R_NO_REMAP
+      #include <R.h>
+      #include <Rinternals.h>
+      #include <R_ext/Random.h>
+      
+      
+      extern void fn(const double* const b__, double* const out___);
+      
+      SEXP fn_(SEXP _args) {
+        // b
+        _args = CDR(_args);
+        SEXP b = CAR(_args);
+        if (TYPEOF(b) != REALSXP) {
+          Rf_error("typeof(b) must be 'double', not '%s'", R_typeToChar(b));
+        }
+        const double* const b__ = REAL(b);
+        const R_xlen_t b__len_ = Rf_xlength(b);
+        
+        if (b__len_ != 1)
+          Rf_error("length(b) must be 1, not %0.f",
+                    (double)b__len_);
+        const R_xlen_t out___len_ = 10;
+        SEXP out_ = PROTECT(Rf_allocVector(REALSXP, out___len_));
+        double* out___ = REAL(out_);
+        
+        GetRNGstate();
+        fn(b__, out___);
+        PutRNGstate();
+        
+        UNPROTECT(1);
+        return out_;
+      }
+

--- a/tests/testthat/helper.R
+++ b/tests/testthat/helper.R
@@ -47,3 +47,8 @@ assign_in_global <- function(...) {
   x <- rlang::dots_list(..., .named = TRUE)
   list2env(x, envir = globalenv())
 }
+
+set_seed_and_call <- function(fun, ...) {
+  set.seed(1234)
+  fun(...)
+}

--- a/tests/testthat/test-runif.R
+++ b/tests/testthat/test-runif.R
@@ -1,0 +1,117 @@
+test_that("runif generates random numbers", {
+  ## test simple runif
+  fn <- function(n) {
+    declare(type(n = integer(1)))
+    runif(n)
+  }
+
+  expect_translation_snapshots(fn)
+  qrunif <- quick(fn)
+
+  expect_identical(
+    set_seed_and_call(runif, 5L),
+    set_seed_and_call(qrunif, 5L)
+  )
+
+  expect_identical(
+    set_seed_and_call(runif, 1L),
+    set_seed_and_call(qrunif, 1L)
+  )
+
+  # scalar runif in fortran local
+  fn <- function(x) {
+    declare(type(x = double(NA)))
+    x * runif(1)
+  }
+  expect_translation_snapshots(fn)
+  qfn <- quick(fn)
+
+  x <- runif(5)
+  expect_identical(
+    set_seed_and_call(fn, x),
+    set_seed_and_call(qfn, x)
+  )
+
+  # 1d runif array in fortran local
+  fn <- function(x) {
+    declare(type(x = double(NA)))
+    x * runif(length(x))
+  }
+  expect_translation_snapshots(fn)
+  qfn <- quick(fn)
+
+  expect_identical(
+    set_seed_and_call(fn, x),
+    set_seed_and_call(qfn, x)
+  )
+})
+
+test_that("runif with min/max", {
+  fn <- function(n, a, b) {
+    declare(
+      type(n = integer(1)),
+      type(a = double(1)),
+      type(b = double(1))
+    )
+    runif(n, a, b)
+  }
+
+  expect_translation_snapshots(fn)
+  qfn <- quick(fn)
+
+  expect_identical(
+    set_seed_and_call(fn, 10L, 3, 11),
+    set_seed_and_call(qfn, 10L, 3, 11)
+  )
+
+  expect_identical(
+    set_seed_and_call(fn, 1L, 3, 11),
+    set_seed_and_call(qfn, 1L, 3, 11)
+  )
+
+  fn <- function(n, b) {
+    declare(
+      type(n = integer(1)),
+      type(b = double(1))
+    )
+    runif(n, max = b)
+  }
+
+  expect_translation_snapshots(fn)
+  qfn <- quick(fn)
+
+  expect_identical(
+    set_seed_and_call(fn, 10L, 20),
+    set_seed_and_call(qfn, 10L, 20)
+  )
+
+  fn <- function(b) {
+    declare(
+      type(b = double(1))
+    )
+    runif(1, max = b)
+  }
+
+  expect_translation_snapshots(fn)
+  qfn <- quick(fn)
+
+  expect_identical(
+    set_seed_and_call(fn, 20),
+    set_seed_and_call(qfn, 20)
+  )
+
+  fn <- function(b) {
+    declare(
+      type(b = double(1))
+    )
+    runif(10, max = b)
+  }
+
+  expect_translation_snapshots(fn)
+  qfn <- quick(fn)
+
+  expect_identical(
+    set_seed_and_call(fn, 20),
+    set_seed_and_call(qfn, 20)
+  )
+})


### PR DESCRIPTION
This lays out a pattern for calling rng-using functions in quickr. Only `runif()` is implemented for now, but the pattern should be straightforward to extend to other distributions. 
See discussion in #22.