### PR TITLE
Add unary "+", "-" and "!"

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,5 @@
 # quickr (development version)
+- Added support for `!` and unary `-` and `+` (#49, @mns-nordicals)
 
 - Functions can now return multiple arrays in a `list()`, optionally
   named (#49, @mns-nordicals).

--- a/R/r2f.R
+++ b/R/r2f.R
@@ -658,13 +658,26 @@ maybe_cast_double <- function(x) {
 }
 
 r2f_handlers[["+"]] <- function(args, scope, ...) {
-  .[left, right] <- lapply(args, r2f, scope, ...)
-  Fortran(glue("({left} + {right})"), conform(left@value, right@value))
+  # Support both binary and unary plus
+  if (length(args) == 1L) {
+    x <- r2f(args[[1L]], scope, ...)
+    # Unary plus is a no-op; keep explicit for clarity
+    Fortran(glue("(+{x})"), x@value)
+  } else {
+    .[left, right] <- lapply(args, r2f, scope, ...)
+    Fortran(glue("({left} + {right})"), conform(left@value, right@value))
+  }
 }
 
 r2f_handlers[["-"]] <- function(args, scope, ...) {
-  .[left, right] <- lapply(args, r2f, scope, ...)
-  Fortran(glue("({left} - {right})"), conform(left@value, right@value))
+  # Support both binary and unary minus
+  if (length(args) == 1L) {
+    x <- r2f(args[[1L]], scope, ...)
+    Fortran(glue("(-{x})"), x@value)
+  } else {
+    .[left, right] <- lapply(args, r2f, scope, ...)
+    Fortran(glue("({left} - {right})"), conform(left@value, right@value))
+  }
 }
 
 r2f_handlers[["*"]] <- function(args, scope = NULL, ...) {
@@ -725,6 +738,16 @@ r2f_handlers[["!="]] <- function(args, scope, ...) {
   var <- conform(left@value, right@value)
   var@mode <- "logical"
   Fortran(glue("({left} /= {right})"), var)
+}
+
+# ---- unary logical not ----
+r2f_handlers[["!"]] <- function(args, scope, ...) {
+  stopifnot(length(args) == 1L)
+  x <- r2f(args[[1L]], scope, ...)
+  if (x@value@mode != "logical") {
+    stop("'!' expects a logical value; numeric coercions not yet supported")
+  }
+  Fortran(glue("(.not. {x})"), x@value)
 }
 
 

--- a/R/r2f.R
+++ b/R/r2f.R
@@ -661,7 +661,6 @@ r2f_handlers[["+"]] <- function(args, scope, ...) {
   # Support both binary and unary plus
   if (length(args) == 1L) {
     x <- r2f(args[[1L]], scope, ...)
-    # Unary plus is a no-op; keep explicit for clarity
     Fortran(glue("(+{x})"), x@value)
   } else {
     .[left, right] <- lapply(args, r2f, scope, ...)

--- a/R/r2f.R
+++ b/R/r2f.R
@@ -661,7 +661,7 @@ r2f_handlers[["+"]] <- function(args, scope, ...) {
   # Support both binary and unary plus
   if (length(args) == 1L) {
     x <- r2f(args[[1L]], scope, ...)
-    Fortran(glue("(+{x})"), Variable(x@value@mode, x@value@dims))
+    Fortran(glue("(+{x})"), x@value)
   } else {
     .[left, right] <- lapply(args, r2f, scope, ...)
     Fortran(glue("({left} + {right})"), conform(left@value, right@value))
@@ -672,7 +672,7 @@ r2f_handlers[["-"]] <- function(args, scope, ...) {
   # Support both binary and unary minus
   if (length(args) == 1L) {
     x <- r2f(args[[1L]], scope, ...)
-    Fortran(glue("(-{x})"), Variable(x@value@mode, x@value@dims))
+    Fortran(glue("(-{x})"), x@value)
   } else {
     .[left, right] <- lapply(args, r2f, scope, ...)
     Fortran(glue("({left} - {right})"), conform(left@value, right@value))
@@ -746,7 +746,7 @@ r2f_handlers[["!"]] <- function(args, scope, ...) {
   if (x@value@mode != "logical") {
     stop("'!' expects a logical value; numeric coercions not yet supported")
   }
-  Fortran(glue("(.not. {x})"), Variable("logical", x@value@dims))
+  Fortran(glue("(.not. {x})"), x@value)
 }
 
 

--- a/R/r2f.R
+++ b/R/r2f.R
@@ -661,7 +661,7 @@ r2f_handlers[["+"]] <- function(args, scope, ...) {
   # Support both binary and unary plus
   if (length(args) == 1L) {
     x <- r2f(args[[1L]], scope, ...)
-    Fortran(glue("(+{x})"), x@value)
+    Fortran(glue("(+{x})"), Variable(x@value@mode, x@value@dims))
   } else {
     .[left, right] <- lapply(args, r2f, scope, ...)
     Fortran(glue("({left} + {right})"), conform(left@value, right@value))
@@ -672,7 +672,7 @@ r2f_handlers[["-"]] <- function(args, scope, ...) {
   # Support both binary and unary minus
   if (length(args) == 1L) {
     x <- r2f(args[[1L]], scope, ...)
-    Fortran(glue("(-{x})"), x@value)
+    Fortran(glue("(-{x})"), Variable(x@value@mode, x@value@dims))
   } else {
     .[left, right] <- lapply(args, r2f, scope, ...)
     Fortran(glue("({left} - {right})"), conform(left@value, right@value))
@@ -746,7 +746,7 @@ r2f_handlers[["!"]] <- function(args, scope, ...) {
   if (x@value@mode != "logical") {
     stop("'!' expects a logical value; numeric coercions not yet supported")
   }
-  Fortran(glue("(.not. {x})"), x@value)
+  Fortran(glue("(.not. {x})"), Variable("logical", x@value@dims))
 }
 
 

--- a/tests/testthat/test-unary-intrinsics.R
+++ b/tests/testthat/test-unary-intrinsics.R
@@ -144,16 +144,3 @@ test_that("unary minus and plus for integer and double", {
   expect_quick_equal(fn_neg_d, list(xd))
   expect_quick_equal(fn_pos_d, list(xd))
 })
-
-test_that("unary results do not alias operand Variable", {
-  # unary minus should not rename x's Variable when assigned to y
-  fn <- function(x) {
-    declare(type(x = integer(n)))
-    y <- -x
-    # x should still be usable after creating y
-    s <- sum(x) + sum(y)
-    list(y = y, original_x = x, sum_x_y = s)
-  }
-  x <- 1:5
-  expect_quick_identical(fn, list(x))
-})

--- a/tests/testthat/test-unary-intrinsics.R
+++ b/tests/testthat/test-unary-intrinsics.R
@@ -144,3 +144,16 @@ test_that("unary minus and plus for integer and double", {
   expect_quick_equal(fn_neg_d, list(xd))
   expect_quick_equal(fn_pos_d, list(xd))
 })
+
+test_that("unary results do not alias operand Variable", {
+  # unary minus should not rename x's Variable when assigned to y
+  fn <- function(x) {
+    declare(type(x = integer(n)))
+    y <- -x
+    # x should still be usable after creating y
+    s <- sum(x) + sum(y)
+    list(y = y, original_x = x, sum_x_y = s)
+  }
+  x <- 1:5
+  expect_quick_identical(fn, list(x))
+})

--- a/tests/testthat/test-unary-intrinsics.R
+++ b/tests/testthat/test-unary-intrinsics.R
@@ -100,3 +100,47 @@ test_that("complex unary intrinsics", {
     expect_quick_equal(fn, z)
   }
 })
+
+
+test_that("unary logical 'not'-operator on vector", {
+  fn <- function(x) {
+    declare(type(x = integer(n)))
+    lgl <- x > 1L
+    not_lgl <- !lgl
+    not_lgl
+  }
+
+  x1 <- -3:3
+  x2 <- 0:5
+  expect_quick_identical(fn, list(x1), list(x2))
+})
+
+test_that("unary minus and plus for integer and double", {
+  fn_neg_i <- function(x) {
+    declare(type(x = integer(n)))
+    y <- -x
+    y
+  }
+  fn_pos_i <- function(x) {
+    declare(type(x = integer(n)))
+    y <- +x
+    y
+  }
+  xi <- -5:5
+  expect_quick_identical(fn_neg_i, list(xi))
+  expect_quick_identical(fn_pos_i, list(xi))
+
+  fn_neg_d <- function(x) {
+    declare(type(x = double(n)))
+    y <- -x
+    y
+  }
+  fn_pos_d <- function(x) {
+    declare(type(x = double(n)))
+    y <- +x
+    y
+  }
+  xd <- -5:5 + 0.5
+  expect_quick_equal(fn_neg_d, list(xd))
+  expect_quick_equal(fn_pos_d, list(xd))
+})


### PR DESCRIPTION
Fixes #52 

Not-operator only works with logical variable. If you want, I guess it could be extended to integer and double where 0 and 0.0 is true and false otherwise. 