### PR TITLE
Ifelse bug

### DIFF
--- a/R/r2f.R
+++ b/R/r2f.R
@@ -881,9 +881,13 @@ r2f_handlers[["<-"]] <- function(args, scope, ...) {
 
   # immutable / copy-on-modify usage of Variable()
   if (is.null(var <- get0(name, scope))) {
-    # this is a binding to a new symbol
-    var <- value@value
+    # The var does not exist -> this is a binding to a new symbol
+    # Create a fresh Variable carrying only mode/dims and a new name.
+    src <- value@value
+    var <- Variable(mode = src@mode, dims = src@dims)
     var@name <- name
+    # keep a reference to the R expression assigned, if available
+    try({ var@r <- attr(value, "r", TRUE) }, silent = TRUE)
     scope[[name]] <- var
   } else {
     # The var already exists, this assignment is a modification / reassignment

--- a/R/r2f.R
+++ b/R/r2f.R
@@ -656,7 +656,7 @@ r2f_handlers[["+"]] <- function(args, scope, ...) {
   # Support both binary and unary plus
   if (length(args) == 1L) {
     x <- r2f(args[[1L]], scope, ...)
-    Fortran(glue("(+{x})"), x@value)
+    Fortran(glue("(+{x})"), Variable(x@value@mode, x@value@dims))
   } else {
     .[left, right] <- lapply(args, r2f, scope, ...)
     Fortran(glue("({left} + {right})"), conform(left@value, right@value))
@@ -667,7 +667,7 @@ r2f_handlers[["-"]] <- function(args, scope, ...) {
   # Support both binary and unary minus
   if (length(args) == 1L) {
     x <- r2f(args[[1L]], scope, ...)
-    Fortran(glue("(-{x})"), x@value)
+    Fortran(glue("(-{x})"), Variable(x@value@mode, x@value@dims))
   } else {
     .[left, right] <- lapply(args, r2f, scope, ...)
     Fortran(glue("({left} - {right})"), conform(left@value, right@value))
@@ -741,7 +741,7 @@ r2f_handlers[["!"]] <- function(args, scope, ...) {
   if (x@value@mode != "logical") {
     stop("'!' expects a logical value; numeric coercions not yet supported")
   }
-  Fortran(glue("(.not. {x})"), x@value)
+  Fortran(glue("(.not. {x})"), Variable("logical", x@value@dims))
 }
 
 

--- a/tests/testthat/test-unary-intrinsics.R
+++ b/tests/testthat/test-unary-intrinsics.R
@@ -144,3 +144,16 @@ test_that("unary minus and plus for integer and double", {
   expect_quick_equal(fn_neg_d, list(xd))
   expect_quick_equal(fn_pos_d, list(xd))
 })
+
+test_that("logical not local used as ifelse mask compiles and runs", {
+  fn <- function(x) {
+    declare(type(x = logical(NA)))
+    y <- !x
+    out <- ifelse(y, 1L, 0L)
+    out
+  }
+
+  # Ensure translation and execution are correct
+  expect_translation_snapshots(fn)
+  expect_quick_identical(fn, list(c(TRUE, FALSE, TRUE)))
+})


### PR DESCRIPTION
Closes #55 and is related to #56 

It seems that codex was kind of right anyway, as it was related to copying `Variable` properties from another variable. The solution is to also create a fresh `Variable` in the assignment handler `["<-"]`.  When we create a fresh `Variable` instance we loose some metadata, so we try to recover the `@r` property.  Please consider if this is the right approach. 

Also added `Variable` fixes for unary `+`, `-` and `!` that somehow was missed in  #56

Codex write up of the root cause: 
# Codex

Root Cause
- When binding a new local via assignment, we reused the source `Variable` object (metadata) with `var <- value@value` (R/r2f.R). If the source came from a function argument, it carried `@is_arg == TRUE`.
- Symbol emission treats external logicals (`is_external = is_arg || is_return`) as integer values from R and emits `(name/=0)` to coerce to Fortran logical.
- Because the local `y` inherited `@is_arg == TRUE`, it was treated as external, so the mask in `ifelse()` became `(y/=0)`. This compares a LOGICAL to INTEGER inside `merge`, which is invalid.

Fix
- Change new-binding creation to allocate a fresh `Variable` with only `mode` and `dims` copied, and a new `@name`. Do not reuse the source `Variable` instance.
- File: `R/r2f.R`
- Before (new symbol case in `<-` handler):