### PR TITLE
Got segfault in devtools::test(filter = "compile-package")

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -14,3 +14,4 @@
 ^\.claude$
 ^CRAN-SUBMISSION$
 ^doc$
+^\.ai$

--- a/R/compile-package.R
+++ b/R/compile-package.R
@@ -28,9 +28,26 @@ compile_package <- function(path = ".") {
   # TODO: need to unset various R_* env vars, or just
   # take a dep on callr
   # TODO: prompt to install pkgload if not available?
+  quickr_dev_path <- if (
+    requireNamespace("pkgload", quietly = TRUE) &&
+      pkgload::is_dev_package("quickr")
+  ) {
+    getNamespaceInfo(asNamespace("quickr"), "path")
+  }
+  load_quickr <- if (
+    is_string(quickr_dev_path) &&
+      nzchar(quickr_dev_path) &&
+      file.exists(file.path(quickr_dev_path, "DESCRIPTION"))
+  ) {
+    sprintf("pkgload::load_all(%s, quiet = TRUE)", shQuote(quickr_dev_path))
+  }
+  r_code <- paste(
+    c(load_quickr, "pkgload::load_all(quiet = TRUE)"),
+    collapse = "; "
+  )
   out <- suppressWarnings(system2(
     file.path(R.home("bin"), "R"),
-    c("-q", "-e", shQuote("pkgload::load_all(quiet = TRUE)")),
+    c("-q", "-e", shQuote(r_code)),
     stdout = TRUE,
     stderr = TRUE
   ))

--- a/tests/testthat/test-compile-package.R
+++ b/tests/testthat/test-compile-package.R
@@ -78,6 +78,8 @@ run_r <- function(code) {
   out
 }
 
+quickr_dev_path <- getNamespaceInfo(asNamespace("quickr"), "path")
+
 test_that("compile_package errors when path is not an R package", {
   temp <- withr::local_tempdir()
   expect_error(
@@ -149,6 +151,7 @@ test_that("pkgload::load_all writes outputs and resolves anonymous quick() names
   code <- paste(
     sprintf("setwd(%s)", shQuote(pkgpath)),
     "suppressPackageStartupMessages(library(pkgload))",
+    sprintf("pkgload::load_all(%s, quiet = TRUE)", shQuote(quickr_dev_path)),
     "pkgload::load_all('.', quiet = TRUE)",
     sep = "; "
   )
@@ -170,6 +173,7 @@ test_that("pkgload::load_all messages when NAMESPACE lacks useDynLib", {
   code <- paste(
     sprintf("setwd(%s)", shQuote(pkgpath)),
     "suppressPackageStartupMessages(library(pkgload))",
+    sprintf("pkgload::load_all(%s, quiet = TRUE)", shQuote(quickr_dev_path)),
     "pkgload::load_all('.', quiet = TRUE)",
     sep = "; "
   )


### PR DESCRIPTION
Below I provide an ai summary of the fix (codex did this mostly by it self)

### Problem

After fetching the latest changes to quickr to my fork and running tests I get two failed tests in `devtools::test(filter = "compile-package")`

```r
── Failed tests ────────────────────────────────────────────────────────────
Error (test-compile-package.R:112:3): compile_package runs pkgload::load_all and writes src outputs
Error: pkgload::load_all() failed with status 139:

[...]

Error (test-compile-package.R:155:3): pkgload::load_all writes outputs and resolves anonymous quick() names
Error in `run_r(code)`: R subprocess failed with status: 139
```

### Solution

It turns out that the solution was that the tests were running with an older installed version of `quickr` and running `devtools::install()` fixed the problem. I was also surprised to it had passed github automated tests. 

Nevertheless, before I figured out the problem I got codex to try an investigate the issue. After learning the "real" problem it still thinks it's changes makes the process more robust. So  if you think the same you can merge these changes and if you think they are not necessary and we should use the installed version in the package tests then you are free to disregard this PR.

note, I have a local folder called .ai that i added to rbuldignore. 

# Segfault investigation: `test-compile-package.R` (AI summary of changes and fix)

## Summary
The segfault was caused by the **subprocess loading an older installed `quickr`** instead of the dev version. The installed version generated a `QuickrEntries` array **without a `{NULL, NULL, 0}` sentinel**, which is required by `R_registerRoutines()`. When the test package’s DLL was loaded, `R_registerRoutines()` walked past the array and crashed (`address 0x1`). Ensuring the subprocess loads the **dev** quickr fixes the crash because the dev version correctly emits the sentinel.

After running `devtools::install()` on main, the segfault stopped. That indicates the crash was triggered because the subprocesses were loading an **installed** quickr that was older than the dev sources. The change still improves robustness because it removes the implicit dependency on whatever installed version happens to be on the library path.

## Environment / Toolchain
From the failing run and checks:
- OS: Fedora Linux 43 (Workstation Edition)
- R: 4.5.2 (2025-10-31)
- C compiler: GCC 15.2.1 (Red Hat 15.2.1-5 / 20251211)
- Fortran compiler: GNU Fortran 15.2.1 (Red Hat 15.2.1-5 / 20251211)

## Evidence / Reproduction
- The segfault occurred during `pkgload::load_all()` in a subprocess while loading the temporary test package DLL.
- With the **installed** quickr, the generated `quickr_entrypoints.c` had:
  ```c
  static const R_ExternalMethodDef QuickrEntries[] = {
    {"add_ab_", (DL_FUNC) &add_ab_, -1}
  };
  ```
  (no terminating `{NULL, NULL, 0}` entry)
- `R_registerRoutines()` expects a sentinel-terminated array. Without it, it reads past the array and crashes (segfault at address `0x1`).

## Fix Implemented
### 1) Ensure `compile_package()` subprocess loads dev quickr
When `compile_package()` launches a fresh `R` subprocess, it now **preloads the dev quickr** (if the current session is a dev package) before calling `pkgload::load_all('.')`:

- File: `R/compile-package.R` (lines 31–53)
- Logic:
  - Detect dev package via `pkgload::is_dev_package("quickr")`
  - Resolve dev path via `getNamespaceInfo(asNamespace("quickr"), "path")`
  - Build `r_code` like:
    ```r
    pkgload::load_all(<dev-path>, quiet = TRUE); pkgload::load_all(quiet = TRUE)
    ```

### 2) Ensure test subprocesses do the same
The tests that use `run_r()` now preload the dev quickr before loading the test package:

- File: `tests/testthat/test-compile-package.R` (lines 81, 151–157, 173–179)
- Adds:
  ```r
  quickr_dev_path <- getNamespaceInfo(asNamespace("quickr"), "path")
  ```
  and injects:
  ```r
  pkgload::load_all(<dev-path>, quiet = TRUE)
  ```
  before `pkgload::load_all('.')` inside the subprocess.

## Why this fixes it
The dev quickr emits `QuickrEntries` with the required sentinel:
```c
static const R_ExternalMethodDef QuickrEntries[] = {
  {"add_ab_", (DL_FUNC) &add_ab_, -1},
  {NULL, NULL, 0}
};
```
With the sentinel present, `R_registerRoutines()` stops safely and the DLL loads without crashing.

## Verification
- `R -q -e 'devtools::test_active_file("tests/testthat/test-compile-package.R")'` passes.
- Full suite `R -q -e 'devtools::test()'` passes.
- `R -q -e 'rcmdcheck::rcmdcheck(error_on = "warning")'` passes (network warnings only).

## Files Changed
- `R/compile-package.R`
- `tests/testthat/test-compile-package.R`
- `.Rbuildignore` (adds `^\.ai$` after `air format .`)

