### PR TITLE
Fix as.integer(a / b) codegen for integer inputs

### DIFF
--- a/R/manifest.R
+++ b/R/manifest.R
@@ -223,6 +223,9 @@ iso_c_binding_symbols <- function(
   if (grepl("\\b[0-9]+\\.[0-9]+_c_double\\b", body_code)) {
     used_iso_bindings <- union(used_iso_bindings, "c_double")
   }
+  if (grepl("\\bc_double\\b", body_code)) {
+    used_iso_bindings <- union(used_iso_bindings, "c_double")
+  }
   if (grepl("\\bc_ptrdiff_t\\b", body_code)) {
     used_iso_bindings <- union(used_iso_bindings, "c_ptrdiff_t")
   }

--- a/tests/testthat/_snaps/float-to-int.md
+++ b/tests/testthat/_snaps/float-to-int.md
@@ -187,3 +187,85 @@
         return out;
       }
 
+# as.integer(integer division) truncates toward zero
+
+    Code
+      fn
+    Output
+      function(a, b) {
+          declare(type(a = integer(n)), type(b = integer(n)))
+          out <- as.integer(a / b)
+          out
+        }
+      <environment: 0x0>
+    Code
+      cat(fsub)
+    Output
+      subroutine fn(a, b, out, a__len_) bind(c)
+        use iso_c_binding, only: c_double, c_int, c_ptrdiff_t
+        implicit none
+      
+        ! manifest start
+        ! sizes
+        integer(c_ptrdiff_t), intent(in), value :: a__len_
+      
+        ! args
+        integer(c_int), intent(in) :: a(a__len_)
+        integer(c_int), intent(in) :: b(a__len_)
+        integer(c_int), intent(out) :: out(a__len_)
+        ! manifest end
+      
+      
+        out = int((real(a, kind=c_double) / real(b, kind=c_double)), kind=c_int)
+      end subroutine
+    Code
+      cat(cwrapper)
+    Output
+      #define R_NO_REMAP
+      #include <R.h>
+      #include <Rinternals.h>
+      
+      
+      extern void fn(
+        const int* const a__, 
+        const int* const b__, 
+        int* const out__, 
+        const R_xlen_t a__len_);
+      
+      SEXP fn_(SEXP _args) {
+        // a
+        _args = CDR(_args);
+        SEXP a = CAR(_args);
+        if (TYPEOF(a) != INTSXP) {
+          Rf_error("typeof(a) must be 'integer', not '%s'", Rf_type2char(TYPEOF(a)));
+        }
+        const int* const a__ = INTEGER(a);
+        const R_xlen_t a__len_ = Rf_xlength(a);
+        
+        // b
+        _args = CDR(_args);
+        SEXP b = CAR(_args);
+        if (TYPEOF(b) != INTSXP) {
+          Rf_error("typeof(b) must be 'integer', not '%s'", Rf_type2char(TYPEOF(b)));
+        }
+        const int* const b__ = INTEGER(b);
+        const R_xlen_t b__len_ = Rf_xlength(b);
+        
+        if (a__len_ != b__len_)
+          Rf_error("length(b) must equal length(a),"
+                   " but are %0.f and %0.f",
+                    (double)b__len_, (double)a__len_);
+        const R_xlen_t out__len_ = a__len_;
+        SEXP out = PROTECT(Rf_allocVector(INTSXP, out__len_));
+        int* out__ = INTEGER(out);
+        
+        fn(
+          a__,
+          b__,
+          out__,
+          a__len_);
+        
+        UNPROTECT(1);
+        return out;
+      }
+

--- a/tests/testthat/test-float-to-int.R
+++ b/tests/testthat/test-float-to-int.R
@@ -37,3 +37,17 @@ test_that("trunc() returns double and truncates toward zero", {
   expect_quick_equal(fn_i, xi)
   expect_identical(typeof(fn_i(xi)), "double")
 })
+
+test_that("as.integer(integer division) truncates toward zero", {
+  fn <- function(a, b) {
+    declare(type(a = integer(n)), type(b = integer(n)))
+    out <- as.integer(a / b)
+    out
+  }
+
+  expect_translation_snapshots(fn)
+
+  a <- as.integer(c(7, -7, 7, -7, 3, -3))
+  b <- as.integer(c(2, 2, -2, -2, 2, 2))
+  expect_quick_identical(fn, list(a, b))
+})


### PR DESCRIPTION
## Summary

Fix a compilation failure for `as.integer(a / b)` when both operands are declared as integers.

`/` correctly promotes integer operands to `real(..., kind=c_double)`, and `as.integer()` then lowers the result back to `int(..., kind=c_int)` so the compiled code matches R\x27s truncation-toward-zero behavior. The bug was that `iso_c_binding` import collection detected `_c_double` literals, but not bare `c_double` usages inside expressions like `real(x, kind=c_double)`. As a result, the generated Fortran could reference `c_double` without importing it, and both `flang` and `gfortran` failed to compile the output.

This change:
- teaches `iso_c_binding` symbol collection to include `c_double` whenever it appears in generated body code
- adds a regression test for `as.integer(a / b)` on integer inputs
- verifies both translation output and execution of the compiled function on signed integer cases

## Reprex

```r
fn <- function(a, b) {
  declare(type(a = integer(n)), type(b = integer(n)))
  as.integer(a / b)
}

q <- quick(fn)
q(as.integer(c(7, -7, 7, -7)), as.integer(c(2, 2, -2, -2)))
# expected:  3 -3 -3  3
```
