### PR TITLE
Prepare test suite for CRAN with smoke tests and CRAN skips

### DIFF
--- a/tests/testthat/helper.R
+++ b/tests/testthat/helper.R
@@ -34,6 +34,11 @@ expect_translation_snapshots <- function(
 }
 
 expect_quick_identical <- function(fn, ...) {
+  dll_paths_before <- loaded_dll_paths()
+  on.exit(
+    cleanup_new_quick_dlls(dll_paths_before),
+    add = TRUE
+  )
   qfn := quick(fn)
   args_list <- rlang::list2(...)
   args_list <- lapply(args_list, function(x) if (!is.list(x)) list(x) else x)
@@ -47,6 +52,11 @@ expect_quick_identical <- function(fn, ...) {
 
 
 expect_quick_equal <- function(fn, ...) {
+  dll_paths_before <- loaded_dll_paths()
+  on.exit(
+    cleanup_new_quick_dlls(dll_paths_before),
+    add = TRUE
+  )
   qfn := quick(fn)
   args_list <- rlang::list2(...)
   args_list <- lapply(args_list, function(x) if (!is.list(x)) list(x) else x)
@@ -67,6 +77,31 @@ assign_in_global <- function(...) {
 set_seed_and_call <- function(fun, ...) {
   set.seed(1234)
   fun(...)
+}
+
+loaded_dll_paths <- function() {
+  unname(vapply(getLoadedDLLs(), function(dll) dll[["path"]], character(1)))
+}
+
+cleanup_new_quick_dlls <- function(before) {
+  temp_root <- normalizePath(tempdir(), winslash = "/", mustWork = TRUE)
+  after <- loaded_dll_paths()
+  new_paths <- setdiff(after, before)
+  new_paths <- new_paths[
+    nzchar(new_paths) &
+      startsWith(new_paths, temp_root) &
+      grepl("-build-", new_paths, fixed = TRUE)
+  ]
+
+  for (path in rev(new_paths)) {
+    tryCatch(dyn.unload(path), error = function(...) NULL)
+    tryCatch(
+      unlink(dirname(path), recursive = TRUE, force = TRUE),
+      error = function(...) NULL
+    )
+  }
+
+  invisible(NULL)
 }
 
 skip_if_no_openmp <- local({

--- a/tests/testthat/test-api-drives-internals.R
+++ b/tests/testthat/test-api-drives-internals.R
@@ -1,6 +1,8 @@
 # Public-API tests that exercise internal inference/hoisting code paths.
 # These replace several direct `quickr:::` unit tests while keeping coverage.
 
+skip_on_cran()
+
 test_that("matrix destination inference gracefully declines non-symbol inputs", {
   matmul_expr_arg <- function(A, B) {
     declare(type(A = double(2, 3)), type(B = double(3, 2)))

--- a/tests/testthat/test-closure-semantics-grid.R
+++ b/tests/testthat/test-closure-semantics-grid.R
@@ -1,3 +1,5 @@
+skip_on_cran()
+
 test_that("direct-call statement closure can host-mutate with x <<- expr", {
   fn <- function(x) {
     declare(type(x = double(NA)))

--- a/tests/testthat/test-codecov-coverage.R
+++ b/tests/testthat/test-codecov-coverage.R
@@ -1,5 +1,7 @@
 # Coverage-oriented public API tests (exercise compiled calls via quick()).
 
+skip_on_cran()
+
 test_that("C bridge size checks handle scalar size args (including dotted args)", {
   fn <- function(n, x) {
     declare(type(n = integer(1)), type(x = double(n)))

--- a/tests/testthat/test-cran-smoke-closures.R
+++ b/tests/testthat/test-cran-smoke-closures.R
@@ -1,0 +1,28 @@
+# Compact end-to-end closure coverage kept on CRAN.
+
+test_that("closure smoke: sapply lowers and runs", {
+  fn <- function(x) {
+    declare(type(x = double(NA)))
+    sapply(seq_along(x), function(i) x[i] + 1.0)
+  }
+
+  set.seed(1)
+  x <- runif(6)
+  expect_quick_identical(fn, list(x))
+})
+
+test_that("closure smoke: local closure host mutation works", {
+  fn <- function(x) {
+    declare(type(x = double(NA)))
+    bump <- function() {
+      x <<- x + 1.0
+      NULL
+    }
+    bump()
+    x
+  }
+
+  set.seed(2)
+  x <- runif(6)
+  expect_quick_identical(fn, list(x))
+})

--- a/tests/testthat/test-cran-smoke-iterables.R
+++ b/tests/testthat/test-cran-smoke-iterables.R
@@ -1,0 +1,14 @@
+# Compact iterable coverage kept on CRAN.
+
+test_that("iterable smoke: for loops over vectors compile and run", {
+  fn <- function(x) {
+    declare(type(x = double(NA)))
+    total <- 0.0
+    for (elt in x) {
+      total <- total + elt
+    }
+    total
+  }
+
+  expect_quick_equal(fn, list(c(0.5, 1.5, 2.5)))
+})

--- a/tests/testthat/test-cran-smoke-matrix.R
+++ b/tests/testthat/test-cran-smoke-matrix.R
@@ -1,0 +1,46 @@
+# Compact matrix/LAPACK coverage kept on CRAN.
+
+test_that("matrix smoke: matmul inference compiles and runs", {
+  fn <- function(A, B) {
+    declare(type(A = double(2, 3)), type(B = double(3, 2)))
+    out <- A %*% B
+    out
+  }
+
+  set.seed(1)
+  A <- matrix(rnorm(6), nrow = 2)
+  B <- matrix(rnorm(6), nrow = 3)
+  expect_quick_equal(fn, list(A = A, B = B))
+})
+
+test_that("matrix smoke: solve, qr.solve, and chol run end-to-end", {
+  solve_vec <- function(A, b) {
+    declare(type(A = double(n, n)), type(b = double(n)))
+    solve(A, b)
+  }
+
+  qr_solve_vec <- function(X, y) {
+    declare(type(X = double(n, k)), type(y = double(n)))
+    qr.solve(X, y)
+  }
+
+  chol_fn <- function(A) {
+    declare(type(A = double(n, n)))
+    chol(A)
+  }
+
+  set.seed(2)
+  n <- 4
+  k <- 2
+
+  base <- matrix(rnorm(n * n), nrow = n)
+  A <- crossprod(base) + diag(n)
+  b <- rnorm(n)
+  expect_quick_equal(solve_vec, list(A = A, b = b))
+  expect_quick_equal(chol_fn, list(A = A))
+
+  X <- matrix(rnorm(6 * k), nrow = 6)
+  y <- rnorm(6)
+  q_qr_solve_vec <- expect_warning(quick(qr_solve_vec), NA)
+  expect_equal(q_qr_solve_vec(X, y), qr.solve(X, y))
+})

--- a/tests/testthat/test-cran-smoke-vector-ops.R
+++ b/tests/testthat/test-cran-smoke-vector-ops.R
@@ -1,0 +1,34 @@
+# Compact vector/reduction coverage kept on CRAN.
+
+test_that("vector smoke: unary intrinsic and rev compile and run", {
+  sin_fn <- function(x) {
+    declare(type(x = double(NA)))
+    sin(x)
+  }
+
+  rev_fn <- function(x) {
+    declare(type(x = double(NA)))
+    rev(x)
+  }
+
+  x <- seq(-1, 1, length.out = 5)
+  expect_quick_equal(sin_fn, list(x))
+  expect_quick_identical(rev_fn, list(c(1, 2, 3)))
+})
+
+test_that("vector smoke: masked reductions and subsets compile and run", {
+  masked_sum <- function(x) {
+    declare(type(x = double(NA)))
+    sum(x[x > 0])
+  }
+
+  subset_sum <- function(m) {
+    declare(type(m = double(NA, NA)))
+    sum(m[m > 3.0])
+  }
+
+  expect_quick_equal(masked_sum, list(c(-2, 1, 3, -4, 5)))
+
+  m <- matrix(as.double(1:6), nrow = 2L, ncol = 3L, byrow = TRUE)
+  expect_quick_equal(subset_sum, list(m))
+})

--- a/tests/testthat/test-for-iterables.R
+++ b/tests/testthat/test-for-iterables.R
@@ -1,5 +1,7 @@
 # Unit tests for `for (... in <iterable>)` lowering
 
+skip_on_cran()
+
 test_that("for() supports parenthesized iterables", {
   sum_i <- function(n) {
     declare(type(n = integer(1)))

--- a/tests/testthat/test-matrix-inference.R
+++ b/tests/testthat/test-matrix-inference.R
@@ -1,3 +1,5 @@
+skip_on_cran()
+
 test_that("matrix ops infer destination sizes for assignments", {
   matmul_infer <- function(A, B) {
     declare(type(A = double(2, 3)), type(B = double(3, 2)))

--- a/tests/testthat/test-matrix-lapack.R
+++ b/tests/testthat/test-matrix-lapack.R
@@ -1,3 +1,5 @@
+skip_on_cran()
+
 test_that("solve matches R for vector, matrix, and inverse", {
   solve_vec <- function(A, b) {
     declare(

--- a/tests/testthat/test-matrix-mul.R
+++ b/tests/testthat/test-matrix-mul.R
@@ -1,3 +1,5 @@
+skip_on_cran()
+
 test_that("matrix multiplication matches R for common shapes", {
   mat_mat <- function(mat_A, mat_B) {
     declare(

--- a/tests/testthat/test-rev.R
+++ b/tests/testthat/test-rev.R
@@ -1,3 +1,5 @@
+skip_on_cran()
+
 test_that("rev() reverses vectors", {
   fn_dbl <- function(x) {
     declare(type(x = double(NA)))

--- a/tests/testthat/test-sapply-closures.R
+++ b/tests/testthat/test-sapply-closures.R
@@ -1,3 +1,5 @@
+skip_on_cran()
+
 test_that("sapply lowers scalar-return closures (named + inline)", {
   fn_named <- function(x) {
     declare(type(x = double(NA)))

--- a/tests/testthat/test-subset-reduction.R
+++ b/tests/testthat/test-subset-reduction.R
@@ -1,3 +1,5 @@
+skip_on_cran()
+
 test_that("[ handles scalar, missing, and logical subscripts", {
   m <- matrix(1:6, nrow = 2L, ncol = 3L, byrow = TRUE)
 

--- a/tests/testthat/test-unary-intrinsics.R
+++ b/tests/testthat/test-unary-intrinsics.R
@@ -1,5 +1,7 @@
 # Unit tests for unary intrinsic functions
 
+skip_on_cran()
+
 test_that("double unary intrinsics", {
   double_intrinsics <- c(
     "sin",


### PR DESCRIPTION
## Summary

Prepare the test suite for CRAN by separating compact smoke coverage from heavier extended coverage.

This keeps representative end-to-end tests on CRAN while skipping the slowest and most exhaustive test files with `skip_on_cran()`.

## Public-facing changes

There are no public API changes in this PR.

## Internal changes

- add compact CRAN smoke tests for closures, iterables, matrix/LAPACK, and vector ops
- mark extended test files with `skip_on_cran()`
- unload temp `quick()` DLLs in test helpers to avoid hitting R's DLL limit during long test runs
