### PR TITLE
Relax default gfortran vectorizer cost model for quickr builds

### DIFF
--- a/R/compiler.R
+++ b/R/compiler.R
@@ -171,6 +171,27 @@ quickr_prefer_flang <- function(
   FALSE
 }
 
+quickr_default_fortran_makevars_lines <- function(
+  config_value = quickr_r_cmd_config_value
+) {
+  fc <- trimws(config_value("FC"))
+  if (!nzchar(fc)) {
+    return(character())
+  }
+
+  compiler <- strsplit(fc, "\\s+")[[1L]][[1L]]
+  compiler <- basename(compiler)
+  if (!grepl("^gfortran(?:-[0-9]+)?(?:\\.exe)?$", compiler)) {
+    return(character())
+  }
+
+  # GCC 12+ uses a very-cheap vectorizer cost model at -O2. That keeps the
+  # default build conservative for loops like quickr's generated array kernels.
+  # Relaxing the cost model restores the vectorized code path without changing
+  # the compiler or generated Fortran source.
+  "PKG_FFLAGS += -fvect-cost-model=cheap"
+}
+
 quickr_fcompiler_env <- function(
   build_dir,
   which = Sys.which,
@@ -178,7 +199,8 @@ quickr_fcompiler_env <- function(
   write_lines = writeLines,
   sysname = Sys.info()[["sysname"]],
   use_openmp = FALSE,
-  link_flags = character()
+  link_flags = character(),
+  config_value = quickr_r_cmd_config_value
 ) {
   stopifnot(is.character(build_dir), length(build_dir) == 1L, nzchar(build_dir))
 
@@ -234,7 +256,13 @@ quickr_fcompiler_env <- function(
     }
   }
 
-  if (!use_flang && !use_openmp) {
+  default_makevars_lines <- if (use_flang) {
+    character()
+  } else {
+    quickr_default_fortran_makevars_lines(config_value = config_value)
+  }
+
+  if (!use_flang && !use_openmp && !length(default_makevars_lines)) {
     return(character())
   }
 
@@ -249,6 +277,7 @@ quickr_fcompiler_env <- function(
         }
       )
     },
+    default_makevars_lines,
     if (use_openmp) openmp_makevars_lines(),
     if (length(link_flags)) {
       paste("PKG_LIBS +=", paste(link_flags, collapse = " "))

--- a/tests/testthat/test-compiler.R
+++ b/tests/testthat/test-compiler.R
@@ -81,6 +81,35 @@ test_that("quickr_prefer_flang respects quickr.fortran_compiler", {
   expect_false(quickr:::quickr_prefer_flang(sysname = "Darwin"))
 })
 
+test_that("quickr_default_fortran_makevars_lines relaxes gfortran cost model", {
+  expect_equal(
+    quickr:::quickr_default_fortran_makevars_lines(
+      config_value = function(name) {
+        if (identical(name, "FC")) "gfortran -m64" else ""
+      }
+    ),
+    "PKG_FFLAGS += -fvect-cost-model=cheap"
+  )
+
+  expect_equal(
+    quickr:::quickr_default_fortran_makevars_lines(
+      config_value = function(name) {
+        if (identical(name, "FC")) "/usr/bin/gfortran-13" else ""
+      }
+    ),
+    "PKG_FFLAGS += -fvect-cost-model=cheap"
+  )
+
+  expect_identical(
+    quickr:::quickr_default_fortran_makevars_lines(
+      config_value = function(name) {
+        if (identical(name, "FC")) "flang-new" else ""
+      }
+    ),
+    character()
+  )
+})
+
 test_that("quickr_fortran_compiler_option validates values", {
   withr::local_options(quickr.fortran_compiler = "auto")
   expect_null(quickr:::quickr_fortran_compiler_option())
@@ -128,6 +157,28 @@ test_that("quickr_fcompiler_env writes Makevars when flang is usable", {
   )
   expect_true(startsWith(env, "R_MAKEVARS_USER="))
   expect_true(file.exists(sub("R_MAKEVARS_USER=", "", env, fixed = TRUE)))
+})
+
+test_that("quickr_fcompiler_env writes Makevars for default gfortran flags", {
+  build_dir <- withr::local_tempdir()
+
+  withr::local_options(quickr.fortran_compiler = "gfortran")
+  env <- quickr:::quickr_fcompiler_env(
+    build_dir = build_dir,
+    which = function(cmd) "",
+    system2 = function(...) "",
+    sysname = "Linux",
+    config_value = function(name) {
+      if (identical(name, "FC")) "gfortran -m64" else ""
+    }
+  )
+
+  expect_true(startsWith(env, "R_MAKEVARS_USER="))
+  makevars_path <- sub("^R_MAKEVARS_USER=", "", env)
+  expect_equal(
+    readLines(makevars_path),
+    "PKG_FFLAGS += -fvect-cost-model=cheap"
+  )
 })
 
 test_that("quickr_fcompiler_env errors when flang is explicitly requested but unavailable", {
@@ -286,7 +337,8 @@ test_that("quickr_fcompiler_env handles flang unavailable for non-explicit reque
     build_dir = build_dir,
     which = function(x) "",
     system2 = function(...) "",
-    sysname = "Darwin"
+    sysname = "Darwin",
+    config_value = function(name) if (identical(name, "FC")) "clang" else ""
   )
   expect_identical(result, character())
 })
@@ -341,7 +393,8 @@ test_that("quickr_fcompiler_env falls back when flang runtime not found non-expl
     build_dir = build_dir,
     which = function(x) if (x == "flang-new") flang else "",
     system2 = function(...) "",
-    sysname = "Darwin"
+    sysname = "Darwin",
+    config_value = function(name) if (identical(name, "FC")) "clang" else ""
   )
   # Should fall back to character() since runtime not found and not explicit
   expect_identical(result, character())

--- a/tests/testthat/test-flang-preference.R
+++ b/tests/testthat/test-flang-preference.R
@@ -63,7 +63,8 @@ test_that("quickr_fcompiler_env returns empty when disabled or unavailable", {
   expect_equal(
     quickr:::quickr_fcompiler_env(
       build_dir,
-      which = which
+      which = which,
+      config_value = function(name) if (identical(name, "FC")) "clang" else ""
     ),
     character()
   )
@@ -72,7 +73,8 @@ test_that("quickr_fcompiler_env returns empty when disabled or unavailable", {
   expect_equal(
     quickr:::quickr_fcompiler_env(
       build_dir,
-      which = which
+      which = which,
+      config_value = function(name) if (identical(name, "FC")) "clang" else ""
     ),
     character()
   )


### PR DESCRIPTION
## Summary

Default `gfortran` builds in quickr were ending up with GCC's conservative `-O2` vectorizer cost model on this Linux toolchain. That left generated array kernels, including the README `convolve()` example, on a slower scalar code path.

This change detects `gfortran` from `R CMD config FC` and writes a temporary `Makevars.quickr` containing:

```make
PKG_FFLAGS += -fvect-cost-model=cheap
```

The change is limited to default `gfortran` builds. `flang` handling is unchanged.

## Motivation

On this machine, the generated quickr convolve kernel regressed relative to the inline C reference even though the source algorithm was the same. Investigation showed:

- the main issue was on the Fortran side, not a large new C/C++ optimization
- `gfortran -O2` was using `-fvect-cost-model=very-cheap`
- relaxing that to `cheap` restored vectorized code generation for the generated kernel

## Changes

- add `quickr_default_fortran_makevars_lines()` to detect default `gfortran` builds
- write `PKG_FFLAGS += -fvect-cost-model=cheap` into the temporary Makevars used by `quickr::compile()`
- keep `flang` behavior unchanged
- add/update compiler tests for the new Makevars behavior

## Testing

Ran:

```sh
R -q -e 'devtools::test(filter = "compiler|flang-preference")'
```
