### PR TITLE
Cache compiler configuration probes

### DIFF
--- a/R/aaa-utils.R
+++ b/R/aaa-utils.R
@@ -56,10 +56,57 @@ quickr_r_cmd <- function(
 
 quickr_compiler_probe_cache <- new.env(parent = emptyenv())
 
+quickr_makevars_paths <- function() {
+  user_makevars <- Sys.getenv("R_MAKEVARS_USER", unset = NA_character_)
+  user_paths <- if (!is.na(user_makevars) && nzchar(user_makevars)) {
+    user_makevars
+  } else {
+    user_root <- Sys.getenv("R_USER", unset = "")
+    if (!nzchar(user_root)) {
+      user_root <- Sys.getenv("HOME", unset = "")
+    }
+    if (nzchar(user_root)) {
+      file.path(user_root, ".R", c("Makevars", "Makevars.win"))
+    } else {
+      character()
+    }
+  }
+
+  site_makevars <- Sys.getenv("R_MAKEVARS_SITE", unset = NA_character_)
+  site_paths <- if (!is.na(site_makevars) && nzchar(site_makevars)) {
+    site_makevars
+  } else {
+    character()
+  }
+
+  unique(c(user_paths, site_paths))
+}
+
+quickr_file_signature <- function(path) {
+  path <- normalizePath(path, winslash = "/", mustWork = FALSE)
+  if (!file.exists(path)) {
+    return(paste(path, "<missing>", sep = "="))
+  }
+
+  info <- file.info(path)
+  hash <- unname(tools::md5sum(path))
+  paste(path, info$size, info$mtime, hash, sep = "=")
+}
+
+quickr_makevars_signature <- function() {
+  paths <- quickr_makevars_paths()
+  if (!length(paths)) {
+    return("")
+  }
+  paste(vapply(paths, quickr_file_signature, character(1)), collapse = "\r")
+}
+
 quickr_toolchain_env_signature <- function() {
   vars <- c(
     "PATH",
     "BINPREF",
+    "HOME",
+    "R_USER",
     "CC",
     "CXX",
     "FC",
@@ -75,7 +122,13 @@ quickr_toolchain_env_signature <- function() {
     "R_MAKEVARS_USER"
   )
   env <- Sys.getenv(vars, unset = NA_character_)
-  paste(names(env), env, sep = "=", collapse = "\r")
+  paste(
+    c(
+      paste(names(env), env, sep = "="),
+      paste("MAKEVARS", quickr_makevars_signature(), sep = "=")
+    ),
+    collapse = "\r"
+  )
 }
 
 quickr_r_cmd_config_cache_key <- function(name) {

--- a/R/aaa-utils.R
+++ b/R/aaa-utils.R
@@ -69,6 +69,22 @@ quickr_default_makevars_names <- function(
   ))
 }
 
+quickr_r_etc_path <- function(
+  file,
+  r_home = R.home(),
+  r_arch = Sys.getenv("R_ARCH", unset = "")
+) {
+  file.path(r_home, paste0("etc", r_arch), file)
+}
+
+quickr_default_site_makevars_path <- function() {
+  quickr_r_etc_path("Makevars.site")
+}
+
+quickr_makeconf_path <- function() {
+  quickr_r_etc_path("Makeconf")
+}
+
 quickr_makevars_paths <- function() {
   user_makevars <- Sys.getenv("R_MAKEVARS_USER", unset = NA_character_)
   user_paths <- if (!is.na(user_makevars) && nzchar(user_makevars)) {
@@ -89,7 +105,7 @@ quickr_makevars_paths <- function() {
   site_paths <- if (!is.na(site_makevars) && nzchar(site_makevars)) {
     site_makevars
   } else {
-    character()
+    quickr_default_site_makevars_path()
   }
 
   unique(c(user_paths, site_paths))
@@ -114,12 +130,17 @@ quickr_makevars_signature <- function() {
   paste(vapply(paths, quickr_file_signature, character(1)), collapse = "\r")
 }
 
+quickr_makeconf_signature <- function() {
+  quickr_file_signature(quickr_makeconf_path())
+}
+
 quickr_toolchain_env_signature <- function() {
   vars <- c(
     "PATH",
     "BINPREF",
     "HOME",
     "R_USER",
+    "R_ARCH",
     "CC",
     "CXX",
     "FC",
@@ -138,7 +159,8 @@ quickr_toolchain_env_signature <- function() {
   paste(
     c(
       paste(names(env), env, sep = "="),
-      paste("MAKEVARS", quickr_makevars_signature(), sep = "=")
+      paste("MAKEVARS", quickr_makevars_signature(), sep = "="),
+      paste("MAKECONF", quickr_makeconf_signature(), sep = "=")
     ),
     collapse = "\r"
   )

--- a/R/aaa-utils.R
+++ b/R/aaa-utils.R
@@ -171,10 +171,24 @@ quickr_file_signature <- function(path) {
   paste(path, info$size, info$mtime, hash, sep = "=")
 }
 
+quickr_makeconf_variables <- function() {
+  path <- quickr_makeconf_path()
+  if (!quickr_regular_file_exists(path)) {
+    return(character())
+  }
+
+  scan <- quickr_makevars_scan_include_paths(
+    normalizePath(path, winslash = "/", mustWork = FALSE),
+    variables = character(),
+    visited = character()
+  )
+  scan$variables
+}
+
 quickr_makevars_include_paths <- function(paths) {
   scan <- quickr_makevars_scan_include_paths(
     normalizePath(paths, winslash = "/", mustWork = FALSE),
-    variables = character(),
+    variables = quickr_makeconf_variables(),
     visited = character()
   )
   scan$paths

--- a/R/aaa-utils.R
+++ b/R/aaa-utils.R
@@ -598,7 +598,10 @@ quickr_makevars_signature <- function() {
 }
 
 quickr_makevars_env_signature <- function() {
-  paths <- quickr_active_makevars_all_paths()
+  paths <- unique(c(
+    quickr_active_makevars_all_paths(),
+    quickr_makefiles_all_paths()
+  ))
   paths <- paths[vapply(paths, quickr_regular_file_exists, logical(1))]
   if (!length(paths)) {
     return("")
@@ -617,7 +620,10 @@ quickr_makevars_env_signature <- function() {
 }
 
 quickr_makevars_has_uncached_functions <- function() {
-  paths <- quickr_active_makevars_all_paths()
+  paths <- unique(c(
+    quickr_active_makevars_all_paths(),
+    quickr_makefiles_all_paths()
+  ))
   paths <- paths[vapply(paths, quickr_regular_file_exists, logical(1))]
   if (!length(paths)) {
     return(FALSE)
@@ -713,13 +719,21 @@ quickr_makefiles_paths <- function() {
   normalizePath(path.expand(paths), winslash = "/", mustWork = FALSE)
 }
 
-quickr_makefiles_signature <- function() {
+quickr_makefiles_all_paths <- function() {
   paths <- quickr_makefiles_paths()
+  if (!length(paths)) {
+    return(character())
+  }
+
+  unique(c(paths, quickr_makevars_include_paths(paths)))
+}
+
+quickr_makefiles_signature <- function() {
+  paths <- quickr_makefiles_all_paths()
   if (!length(paths)) {
     return("")
   }
 
-  paths <- unique(c(paths, quickr_makevars_include_paths(paths)))
   paste(vapply(paths, quickr_file_signature, character(1)), collapse = "\r")
 }
 

--- a/R/aaa-utils.R
+++ b/R/aaa-utils.R
@@ -85,25 +85,38 @@ quickr_makeconf_path <- function() {
   quickr_r_etc_path("Makeconf")
 }
 
+quickr_regular_file_exists <- function(path) {
+  info <- file.info(path)
+  !is.na(info$isdir) && !info$isdir
+}
+
+quickr_default_user_makevars_paths <- function() {
+  user_roots <- unique(c(
+    Sys.getenv("HOME", unset = ""),
+    Sys.getenv("R_USER", unset = "")
+  ))
+  user_roots <- user_roots[nzchar(user_roots)]
+  if (!length(user_roots)) {
+    return(character())
+  }
+
+  as.vector(outer(
+    user_roots,
+    file.path(".R", quickr_default_makevars_names()),
+    file.path
+  ))
+}
+
 quickr_makevars_paths <- function() {
   user_makevars <- Sys.getenv("R_MAKEVARS_USER", unset = NA_character_)
   user_paths <- if (!is.na(user_makevars) && nzchar(user_makevars)) {
-    user_makevars
-  } else {
-    user_roots <- unique(c(
-      Sys.getenv("HOME", unset = ""),
-      Sys.getenv("R_USER", unset = "")
-    ))
-    user_roots <- user_roots[nzchar(user_roots)]
-    if (length(user_roots)) {
-      as.vector(outer(
-        user_roots,
-        file.path(".R", quickr_default_makevars_names()),
-        file.path
-      ))
+    if (quickr_regular_file_exists(user_makevars)) {
+      user_makevars
     } else {
-      character()
+      unique(c(user_makevars, quickr_default_user_makevars_paths()))
     }
+  } else {
+    quickr_default_user_makevars_paths()
   }
 
   site_makevars <- Sys.getenv("R_MAKEVARS_SITE", unset = NA_character_)
@@ -118,7 +131,7 @@ quickr_makevars_paths <- function() {
 
 quickr_file_signature <- function(path) {
   path <- normalizePath(path, winslash = "/", mustWork = FALSE)
-  if (!file.exists(path)) {
+  if (!quickr_regular_file_exists(path)) {
     return(paste(path, "<missing>", sep = "="))
   }
 
@@ -140,7 +153,7 @@ quickr_makevars_include_paths_impl <- function(paths, visited) {
   out <- character()
 
   for (path in paths) {
-    if (!file.exists(path)) {
+    if (!quickr_regular_file_exists(path)) {
       next
     }
 
@@ -308,13 +321,73 @@ quickr_expand_makevars_include_globs <- function(paths) {
   normalizePath(out, winslash = "/", mustWork = FALSE)
 }
 
-quickr_makevars_signature <- function() {
+quickr_makevars_all_paths <- function() {
   paths <- quickr_makevars_paths()
+  if (!length(paths)) {
+    return(character())
+  }
+
+  unique(c(paths, quickr_makevars_include_paths(paths)))
+}
+
+quickr_makevars_signature <- function() {
+  paths <- quickr_makevars_all_paths()
   if (!length(paths)) {
     return("")
   }
-  paths <- unique(c(paths, quickr_makevars_include_paths(paths)))
   paste(vapply(paths, quickr_file_signature, character(1)), collapse = "\r")
+}
+
+quickr_makevars_env_signature <- function() {
+  paths <- quickr_makevars_all_paths()
+  paths <- paths[vapply(paths, quickr_regular_file_exists, logical(1))]
+  if (!length(paths)) {
+    return("")
+  }
+
+  refs <- unique(unlist(
+    lapply(paths, quickr_makevars_variable_refs),
+    use.names = FALSE
+  ))
+  if (!length(refs)) {
+    return("")
+  }
+
+  values <- vapply(refs, quickr_makevars_env_value, character(1))
+  paste(paste(names(values), values, sep = "="), collapse = "\r")
+}
+
+quickr_makevars_variable_refs <- function(path) {
+  lines <- readLines(path, warn = FALSE)
+  lines <- quickr_join_makevars_continuations(lines)
+  lines <- vapply(lines, quickr_strip_make_comment, character(1))
+  quickr_makevars_text_variable_refs(paste(lines, collapse = "\n"))
+}
+
+quickr_makevars_text_variable_refs <- function(text) {
+  matches <- gregexpr(
+    "\\$\\(([A-Za-z_][A-Za-z0-9_.-]*)\\)|\\$\\{([A-Za-z_][A-Za-z0-9_.-]*)\\}",
+    text,
+    perl = TRUE
+  )
+  tokens <- regmatches(text, matches)[[1]]
+  if (!length(tokens)) {
+    return(character())
+  }
+
+  unique(sub(
+    "^\\$[({]([A-Za-z_][A-Za-z0-9_.-]*)[)}]$",
+    "\\1",
+    tokens
+  ))
+}
+
+quickr_makevars_env_value <- function(name) {
+  if (identical(name, "R_HOME")) {
+    return(R.home())
+  }
+
+  Sys.getenv(name, unset = "")
 }
 
 quickr_makeconf_signature <- function() {
@@ -347,6 +420,7 @@ quickr_toolchain_env_signature <- function() {
     c(
       paste(names(env), env, sep = "="),
       paste("MAKEVARS", quickr_makevars_signature(), sep = "="),
+      paste("MAKEVARS_ENV", quickr_makevars_env_signature(), sep = "="),
       paste("MAKECONF", quickr_makeconf_signature(), sep = "=")
     ),
     collapse = "\r"

--- a/R/aaa-utils.R
+++ b/R/aaa-utils.R
@@ -54,11 +54,72 @@ quickr_r_cmd <- function(
   r_cmd
 }
 
+quickr_compiler_probe_cache <- new.env(parent = emptyenv())
+
+quickr_toolchain_env_signature <- function() {
+  vars <- c(
+    "PATH",
+    "BINPREF",
+    "CC",
+    "CXX",
+    "FC",
+    "F77",
+    "CFLAGS",
+    "CXXFLAGS",
+    "FFLAGS",
+    "FCFLAGS",
+    "LDFLAGS",
+    "LIBS",
+    "MAKE",
+    "R_MAKEVARS_SITE",
+    "R_MAKEVARS_USER"
+  )
+  env <- Sys.getenv(vars, unset = NA_character_)
+  paste(names(env), env, sep = "=", collapse = "\r")
+}
+
+quickr_r_cmd_config_cache_key <- function(name) {
+  paste("r_cmd_config", name, quickr_toolchain_env_signature(), sep = "\r")
+}
+
+quickr_cached_r_cmd_config_value <- function(
+  name,
+  cache = quickr_compiler_probe_cache
+) {
+  stopifnot(is_string(name), is.environment(cache))
+
+  cache_key <- quickr_r_cmd_config_cache_key(name)
+  cached <- get0(cache_key, envir = cache, inherits = FALSE, ifnotfound = NULL)
+  if (is.null(cached)) {
+    probe <- quickr_r_cmd_config_probe(name)
+    cached <- probe$value
+    if (isTRUE(probe$ok)) {
+      assign(cache_key, cached, envir = cache)
+    }
+  }
+
+  cached
+}
+
 quickr_r_cmd_config_value <- function(
   name,
   r_cmd = quickr_r_cmd(),
   system2 = base::system2
 ) {
+  quickr_r_cmd_config_probe(
+    name = name,
+    r_cmd = r_cmd,
+    system2 = system2
+  )$value
+}
+
+quickr_r_cmd_config_probe <- function(
+  name,
+  r_cmd = quickr_r_cmd(),
+  system2 = base::system2
+) {
+  stopifnot(is_string(name), is_string(r_cmd), is.function(system2))
+
   out <- tryCatch(
     suppressWarnings(system2(
       r_cmd,
@@ -66,17 +127,21 @@ quickr_r_cmd_config_value <- function(
       stdout = TRUE,
       stderr = FALSE
     )),
-    error = function(e) character()
+    error = function(e) structure(character(), status = 1L)
   )
   status <- attr(out, "status")
   if (!is.null(status)) {
-    return("")
+    return(list(value = "", ok = FALSE))
   }
   value <- trimws(paste(out, collapse = " "))
-  if (!nzchar(value) || grepl("^ERROR:", value)) {
-    return("")
+  if (!nzchar(value)) {
+    return(list(value = "", ok = TRUE))
   }
-  value
+  if (grepl("^ERROR:", value)) {
+    return(list(value = "", ok = FALSE))
+  }
+
+  list(value = value, ok = TRUE)
 }
 
 

--- a/R/aaa-utils.R
+++ b/R/aaa-utils.R
@@ -692,6 +692,7 @@ quickr_makefiles_signature <- function() {
     return("")
   }
 
+  paths <- unique(c(paths, quickr_makevars_include_paths(paths)))
   paste(vapply(paths, quickr_file_signature, character(1)), collapse = "\r")
 }
 

--- a/R/aaa-utils.R
+++ b/R/aaa-utils.R
@@ -56,6 +56,19 @@ quickr_r_cmd <- function(
 
 quickr_compiler_probe_cache <- new.env(parent = emptyenv())
 
+quickr_default_makevars_names <- function(
+  platform = R.version$platform
+) {
+  unique(c(
+    paste0("Makevars-", platform),
+    "Makevars.ucrt",
+    "Makevars.win64",
+    "Makevars.win32",
+    "Makevars.win",
+    "Makevars"
+  ))
+}
+
 quickr_makevars_paths <- function() {
   user_makevars <- Sys.getenv("R_MAKEVARS_USER", unset = NA_character_)
   user_paths <- if (!is.na(user_makevars) && nzchar(user_makevars)) {
@@ -66,7 +79,7 @@ quickr_makevars_paths <- function() {
       user_root <- Sys.getenv("HOME", unset = "")
     }
     if (nzchar(user_root)) {
-      file.path(user_root, ".R", c("Makevars", "Makevars.win"))
+      file.path(user_root, ".R", quickr_default_makevars_names())
     } else {
       character()
     }

--- a/R/aaa-utils.R
+++ b/R/aaa-utils.R
@@ -171,8 +171,16 @@ quickr_file_signature <- function(path) {
   paste(path, info$size, info$mtime, hash, sep = "=")
 }
 
-quickr_makeconf_variables <- function() {
-  variables <- character()
+quickr_makevars_seed_variables <- function(config_name = "") {
+  if (!nzchar(config_name)) {
+    return(character())
+  }
+
+  c(VAR = config_name)
+}
+
+quickr_makeconf_variables <- function(config_name = "") {
+  variables <- quickr_makevars_seed_variables(config_name)
   makefiles <- quickr_makefiles_paths()
   if (length(makefiles)) {
     scan <- quickr_makevars_scan_include_paths(
@@ -196,10 +204,10 @@ quickr_makeconf_variables <- function() {
   scan$variables
 }
 
-quickr_makevars_include_paths <- function(paths) {
+quickr_makevars_include_paths <- function(paths, config_name = "") {
   scan <- quickr_makevars_scan_include_paths(
     normalizePath(paths, winslash = "/", mustWork = FALSE),
-    variables = quickr_makeconf_variables(),
+    variables = quickr_makeconf_variables(config_name),
     visited = character()
   )
   scan$paths
@@ -570,37 +578,37 @@ quickr_expand_makevars_include_globs <- function(paths) {
   normalizePath(out, winslash = "/", mustWork = FALSE)
 }
 
-quickr_makevars_all_paths <- function() {
+quickr_makevars_all_paths <- function(config_name = "") {
   paths <- quickr_makevars_paths()
   active_paths <- quickr_active_makevars_paths()
   if (!length(paths) && !length(active_paths)) {
     return(character())
   }
 
-  unique(c(paths, quickr_makevars_include_paths(active_paths)))
+  unique(c(paths, quickr_makevars_include_paths(active_paths, config_name)))
 }
 
-quickr_active_makevars_all_paths <- function() {
+quickr_active_makevars_all_paths <- function(config_name = "") {
   paths <- quickr_active_makevars_paths()
   if (!length(paths)) {
     return(character())
   }
 
-  unique(c(paths, quickr_makevars_include_paths(paths)))
+  unique(c(paths, quickr_makevars_include_paths(paths, config_name)))
 }
 
-quickr_makevars_signature <- function() {
-  paths <- quickr_makevars_all_paths()
+quickr_makevars_signature <- function(config_name = "") {
+  paths <- quickr_makevars_all_paths(config_name)
   if (!length(paths)) {
     return("")
   }
   paste(vapply(paths, quickr_file_signature, character(1)), collapse = "\r")
 }
 
-quickr_makevars_env_signature <- function() {
+quickr_makevars_env_signature <- function(config_name = "") {
   paths <- unique(c(
-    quickr_active_makevars_all_paths(),
-    quickr_makefiles_all_paths()
+    quickr_active_makevars_all_paths(config_name),
+    quickr_makefiles_all_paths(config_name)
   ))
   paths <- paths[vapply(paths, quickr_regular_file_exists, logical(1))]
   if (!length(paths)) {
@@ -619,10 +627,10 @@ quickr_makevars_env_signature <- function() {
   paste(paste(names(values), values, sep = "="), collapse = "\r")
 }
 
-quickr_makevars_has_uncached_functions <- function() {
+quickr_makevars_has_uncached_functions <- function(config_name = "") {
   paths <- unique(c(
-    quickr_active_makevars_all_paths(),
-    quickr_makefiles_all_paths()
+    quickr_active_makevars_all_paths(config_name),
+    quickr_makefiles_all_paths(config_name)
   ))
   paths <- paths[vapply(paths, quickr_regular_file_exists, logical(1))]
   if (!length(paths)) {
@@ -704,8 +712,35 @@ quickr_makevars_env_value <- function(name) {
   Sys.getenv(name, unset = "")
 }
 
-quickr_makeconf_signature <- function() {
-  quickr_file_signature(quickr_makeconf_path())
+quickr_makeconf_paths <- function(config_name = "") {
+  path <- quickr_makeconf_path()
+  if (!quickr_regular_file_exists(path)) {
+    return(normalizePath(path, winslash = "/", mustWork = FALSE))
+  }
+
+  variables <- quickr_makevars_seed_variables(config_name)
+  makefiles <- quickr_makefiles_paths()
+  if (length(makefiles)) {
+    scan <- quickr_makevars_scan_include_paths(
+      makefiles,
+      variables = variables,
+      visited = character()
+    )
+    variables <- scan$variables
+  }
+
+  path <- normalizePath(path, winslash = "/", mustWork = FALSE)
+  scan <- quickr_makevars_scan_include_paths(
+    path,
+    variables = variables,
+    visited = character()
+  )
+  unique(c(path, scan$paths))
+}
+
+quickr_makeconf_signature <- function(config_name = "") {
+  paths <- quickr_makeconf_paths(config_name)
+  paste(vapply(paths, quickr_file_signature, character(1)), collapse = "\r")
 }
 
 quickr_makefiles_paths <- function() {
@@ -719,17 +754,22 @@ quickr_makefiles_paths <- function() {
   normalizePath(path.expand(paths), winslash = "/", mustWork = FALSE)
 }
 
-quickr_makefiles_all_paths <- function() {
+quickr_makefiles_all_paths <- function(config_name = "") {
   paths <- quickr_makefiles_paths()
   if (!length(paths)) {
     return(character())
   }
 
-  unique(c(paths, quickr_makevars_include_paths(paths)))
+  scan <- quickr_makevars_scan_include_paths(
+    paths,
+    variables = quickr_makevars_seed_variables(config_name),
+    visited = character()
+  )
+  unique(c(paths, scan$paths))
 }
 
-quickr_makefiles_signature <- function() {
-  paths <- quickr_makefiles_all_paths()
+quickr_makefiles_signature <- function(config_name = "") {
+  paths <- quickr_makefiles_all_paths(config_name)
   if (!length(paths)) {
     return("")
   }
@@ -737,7 +777,7 @@ quickr_makefiles_signature <- function() {
   paste(vapply(paths, quickr_file_signature, character(1)), collapse = "\r")
 }
 
-quickr_toolchain_env_signature <- function() {
+quickr_toolchain_env_signature <- function(config_name = "") {
   vars <- c(
     "PATH",
     "BINPREF",
@@ -764,17 +804,25 @@ quickr_toolchain_env_signature <- function() {
   paste(
     c(
       paste(names(env), env, sep = "="),
-      paste("MAKEVARS", quickr_makevars_signature(), sep = "="),
-      paste("MAKEVARS_ENV", quickr_makevars_env_signature(), sep = "="),
-      paste("MAKEFILES_FILES", quickr_makefiles_signature(), sep = "="),
-      paste("MAKECONF", quickr_makeconf_signature(), sep = "=")
+      paste("MAKEVARS", quickr_makevars_signature(config_name), sep = "="),
+      paste(
+        "MAKEVARS_ENV",
+        quickr_makevars_env_signature(config_name),
+        sep = "="
+      ),
+      paste(
+        "MAKEFILES_FILES",
+        quickr_makefiles_signature(config_name),
+        sep = "="
+      ),
+      paste("MAKECONF", quickr_makeconf_signature(config_name), sep = "=")
     ),
     collapse = "\r"
   )
 }
 
 quickr_r_cmd_config_cache_key <- function(name) {
-  paste("r_cmd_config", name, quickr_toolchain_env_signature(), sep = "\r")
+  paste("r_cmd_config", name, quickr_toolchain_env_signature(name), sep = "\r")
 }
 
 quickr_cached_r_cmd_config_value <- function(
@@ -783,7 +831,7 @@ quickr_cached_r_cmd_config_value <- function(
 ) {
   stopifnot(is_string(name), is.environment(cache))
 
-  if (quickr_makevars_has_uncached_functions()) {
+  if (quickr_makevars_has_uncached_functions(name)) {
     return(quickr_r_cmd_config_probe(name)$value)
   }
 

--- a/R/aaa-utils.R
+++ b/R/aaa-utils.R
@@ -115,10 +115,12 @@ quickr_makevars_paths <- function() {
   }
 
   site_makevars <- Sys.getenv("R_MAKEVARS_SITE", unset = NA_character_)
-  site_paths <- if (!is.na(site_makevars) && nzchar(site_makevars)) {
+  site_paths <- if (is.na(site_makevars)) {
+    quickr_default_site_makevars_path()
+  } else if (nzchar(site_makevars)) {
     site_makevars
   } else {
-    quickr_default_site_makevars_path()
+    character()
   }
 
   unique(c(site_paths, user_paths))
@@ -135,12 +137,14 @@ quickr_first_existing_file <- function(paths) {
 
 quickr_active_makevars_paths <- function() {
   site_makevars <- Sys.getenv("R_MAKEVARS_SITE", unset = NA_character_)
-  site_path <- if (!is.na(site_makevars) && nzchar(site_makevars)) {
+  site_path <- if (is.na(site_makevars)) {
+    quickr_default_site_makevars_path()
+  } else if (nzchar(site_makevars)) {
     site_makevars
   } else {
-    quickr_default_site_makevars_path()
+    character()
   }
-  site_path <- if (quickr_regular_file_exists(site_path)) {
+  site_path <- if (length(site_path) && quickr_regular_file_exists(site_path)) {
     site_path
   } else {
     character()
@@ -172,12 +176,14 @@ quickr_file_signature <- function(path) {
 }
 
 quickr_makevars_seed_variables <- function(config_name = "") {
-  if (!nzchar(config_name)) {
-    return(character())
+  variables <- c(R_HOME = R.home())
+  command_line_variables <- "R_HOME"
+  if (nzchar(config_name)) {
+    variables <- c(variables, VAR = config_name)
+    command_line_variables <- c(command_line_variables, "VAR")
   }
 
-  variables <- c(VAR = config_name)
-  attr(variables, "quickr_command_line_variables") <- "VAR"
+  attr(variables, "quickr_command_line_variables") <- command_line_variables
   variables
 }
 

--- a/R/aaa-utils.R
+++ b/R/aaa-utils.R
@@ -189,7 +189,7 @@ quickr_makevars_seed_variables <- function(config_name = "") {
 
 quickr_makeconf_variables <- function(config_name = "") {
   variables <- quickr_makevars_seed_variables(config_name)
-  makefiles <- quickr_makefiles_paths()
+  makefiles <- quickr_makefiles_paths(config_name)
   if (length(makefiles)) {
     scan <- quickr_makevars_scan_include_paths(
       makefiles,
@@ -701,11 +701,13 @@ quickr_file_has_makevars_uncached_function <- function(path) {
   function_pattern <- "\\$\\([A-Za-z_][A-Za-z0-9_.-]*[[:space:]]|\\$\\{[A-Za-z_][A-Za-z0-9_.-]*[[:space:]]"
   substitution_pattern <- "\\$\\([A-Za-z_][A-Za-z0-9_.-]*:[^)]*\\)|\\$\\{[A-Za-z_][A-Za-z0-9_.-]*:[^}]*\\}"
   shell_assignment_pattern <- "^[[:space:]]*(?:(?:export|override|private)[[:space:]]+)*[A-Za-z_][A-Za-z0-9_.-]*[[:space:]]*!="
+  indirect_ref_pattern <- "\\$[({]\\$[({]"
   any(grepl(
     paste(
       function_pattern,
       substitution_pattern,
       shell_assignment_pattern,
+      indirect_ref_pattern,
       sep = "|"
     ),
     lines,
@@ -789,7 +791,7 @@ quickr_makeconf_paths <- function(config_name = "") {
   }
 
   variables <- quickr_makevars_seed_variables(config_name)
-  makefiles <- quickr_makefiles_paths()
+  makefiles <- quickr_makefiles_paths(config_name)
   if (length(makefiles)) {
     scan <- quickr_makevars_scan_include_paths(
       makefiles,
@@ -813,19 +815,23 @@ quickr_makeconf_signature <- function(config_name = "") {
   paste(vapply(paths, quickr_file_signature, character(1)), collapse = "\r")
 }
 
-quickr_makefiles_paths <- function() {
+quickr_makefiles_paths <- function(config_name = "") {
   makefiles <- Sys.getenv("MAKEFILES", unset = "")
   if (!nzchar(makefiles)) {
     return(character())
   }
 
+  makefiles <- quickr_expand_makevars_variables(
+    makefiles,
+    quickr_makevars_seed_variables(config_name)
+  )
   paths <- strsplit(makefiles, "[[:space:]]+")[[1]]
   paths <- paths[nzchar(paths)]
   normalizePath(path.expand(paths), winslash = "/", mustWork = FALSE)
 }
 
 quickr_makefiles_all_paths <- function(config_name = "") {
-  paths <- quickr_makefiles_paths()
+  paths <- quickr_makefiles_paths(config_name)
   if (!length(paths)) {
     return(character())
   }

--- a/R/aaa-utils.R
+++ b/R/aaa-utils.R
@@ -127,11 +127,193 @@ quickr_file_signature <- function(path) {
   paste(path, info$size, info$mtime, hash, sep = "=")
 }
 
+quickr_makevars_include_paths <- function(paths) {
+  quickr_makevars_include_paths_impl(
+    normalizePath(paths, winslash = "/", mustWork = FALSE),
+    visited = character()
+  )
+}
+
+quickr_makevars_include_paths_impl <- function(paths, visited) {
+  paths <- unique(normalizePath(paths, winslash = "/", mustWork = FALSE))
+  paths <- setdiff(paths, visited)
+  out <- character()
+
+  for (path in paths) {
+    if (!file.exists(path)) {
+      next
+    }
+
+    included <- quickr_makevars_direct_include_paths(path)
+    out <- unique(c(out, included))
+    if (length(included)) {
+      out <- unique(c(
+        out,
+        quickr_makevars_include_paths_impl(included, c(visited, path))
+      ))
+    }
+  }
+
+  out
+}
+
+quickr_makevars_direct_include_paths <- function(path) {
+  lines <- readLines(path, warn = FALSE)
+  lines <- quickr_join_makevars_continuations(lines)
+  variables <- quickr_makevars_variable_map(lines)
+  include_paths <- unlist(
+    lapply(
+      lines,
+      quickr_makevars_line_include_paths,
+      variables = variables,
+      makevars_path = path
+    ),
+    use.names = FALSE
+  )
+
+  unique(include_paths)
+}
+
+quickr_join_makevars_continuations <- function(lines) {
+  out <- character()
+  current <- ""
+
+  for (line in lines) {
+    if (nzchar(current)) {
+      line <- paste(current, trimws(line, which = "left"))
+    }
+
+    if (grepl("\\\\$", line)) {
+      current <- sub("\\\\$", "", line)
+      next
+    }
+
+    out <- c(out, line)
+    current <- ""
+  }
+
+  if (nzchar(current)) {
+    out <- c(out, current)
+  }
+
+  out
+}
+
+quickr_makevars_variable_map <- function(lines) {
+  lines <- trimws(vapply(lines, quickr_strip_make_comment, character(1)))
+  assignments <- regexec(
+    "^([A-Za-z_][A-Za-z0-9_.-]*)[[:space:]]*[:?+]?=[[:space:]]*(.*)$",
+    lines,
+    perl = TRUE
+  )
+  matches <- regmatches(lines, assignments)
+  matches <- matches[lengths(matches) == 3L]
+  if (!length(matches)) {
+    return(character())
+  }
+
+  values <- vapply(matches, `[[`, character(1), 3L)
+  names(values) <- vapply(matches, `[[`, character(1), 2L)
+  values
+}
+
+quickr_makevars_line_include_paths <- function(
+  line,
+  variables,
+  makevars_path
+) {
+  line <- trimws(quickr_strip_make_comment(line))
+  match <- regexec(
+    "^(-?include|sinclude)[[:space:]]+(.+)$",
+    line,
+    perl = TRUE
+  )
+  parts <- regmatches(line, match)[[1]]
+  if (length(parts) != 3L) {
+    return(character())
+  }
+
+  spec <- quickr_expand_makevars_variables(parts[[3]], variables)
+  paths <- strsplit(trimws(spec), "[[:space:]]+")[[1]]
+  paths <- paths[nzchar(paths)]
+  paths <- unlist(
+    lapply(paths, quickr_resolve_makevars_include_path, makevars_path),
+    use.names = FALSE
+  )
+
+  unique(paths)
+}
+
+quickr_strip_make_comment <- function(line) {
+  sub("(^|[^\\\\])#.*$", "\\1", line, perl = TRUE)
+}
+
+quickr_expand_makevars_variables <- function(text, variables) {
+  for (i in seq_len(20L)) {
+    match <- regexpr(
+      "\\$\\(([A-Za-z_][A-Za-z0-9_.-]*)\\)|\\$\\{([A-Za-z_][A-Za-z0-9_.-]*)\\}",
+      text,
+      perl = TRUE
+    )
+    if (match[[1]] == -1L) {
+      break
+    }
+
+    token <- regmatches(text, match)
+    name <- sub("^\\$[({]([A-Za-z_][A-Za-z0-9_.-]*)[)}]$", "\\1", token)
+    value <- quickr_makevars_variable_value(name, variables)
+    regmatches(text, match) <- value
+  }
+
+  text
+}
+
+quickr_makevars_variable_value <- function(name, variables) {
+  if (name %in% names(variables)) {
+    return(variables[[name]])
+  }
+
+  if (identical(name, "R_HOME")) {
+    return(R.home())
+  }
+
+  Sys.getenv(name, unset = "")
+}
+
+quickr_resolve_makevars_include_path <- function(path, makevars_path) {
+  path <- path.expand(path)
+  if (grepl("^(/|[A-Za-z]:[/\\\\])", path)) {
+    return(quickr_expand_makevars_include_globs(path))
+  }
+
+  quickr_expand_makevars_include_globs(unique(c(
+    path,
+    file.path(dirname(makevars_path), path)
+  )))
+}
+
+quickr_expand_makevars_include_globs <- function(paths) {
+  out <- unlist(
+    lapply(paths, \(path) {
+      matches <- Sys.glob(path)
+      if (length(matches)) {
+        matches
+      } else {
+        path
+      }
+    }),
+    use.names = FALSE
+  )
+
+  normalizePath(out, winslash = "/", mustWork = FALSE)
+}
+
 quickr_makevars_signature <- function() {
   paths <- quickr_makevars_paths()
   if (!length(paths)) {
     return("")
   }
+  paths <- unique(c(paths, quickr_makevars_include_paths(paths)))
   paste(vapply(paths, quickr_file_signature, character(1)), collapse = "\r")
 }
 

--- a/R/aaa-utils.R
+++ b/R/aaa-utils.R
@@ -316,6 +316,19 @@ quickr_makevars_condition_result <- function(line, variables) {
   }
 
   match <- regexec(
+    "^(ifeq|ifneq)[[:space:]]+(['\"])(.*)\\2[[:space:]]+(['\"])(.*)\\4$",
+    line,
+    perl = TRUE
+  )
+  parts <- regmatches(line, match)[[1]]
+  if (length(parts) == 6L) {
+    left <- quickr_makevars_condition_value(parts[[4]], variables)
+    right <- quickr_makevars_condition_value(parts[[6]], variables)
+    equal <- identical(left, right)
+    return(if (identical(parts[[2]], "ifeq")) equal else !equal)
+  }
+
+  match <- regexec(
     "^(ifdef|ifndef)[[:space:]]+(.+)$",
     line,
     perl = TRUE

--- a/R/aaa-utils.R
+++ b/R/aaa-utils.R
@@ -604,7 +604,7 @@ quickr_makevars_has_uncached_functions <- function() {
 quickr_file_has_makevars_uncached_function <- function(path) {
   lines <- readLines(path, warn = FALSE)
   any(grepl(
-    "\\$\\((shell|wildcard)[[:space:]]|\\$\\{(shell|wildcard)[[:space:]]",
+    "\\$\\([A-Za-z_][A-Za-z0-9_.-]*[[:space:]]|\\$\\{[A-Za-z_][A-Za-z0-9_.-]*[[:space:]]",
     lines,
     perl = TRUE
   ))
@@ -675,6 +675,26 @@ quickr_makeconf_signature <- function() {
   quickr_file_signature(quickr_makeconf_path())
 }
 
+quickr_makefiles_paths <- function() {
+  makefiles <- Sys.getenv("MAKEFILES", unset = "")
+  if (!nzchar(makefiles)) {
+    return(character())
+  }
+
+  paths <- strsplit(makefiles, "[[:space:]]+")[[1]]
+  paths <- paths[nzchar(paths)]
+  normalizePath(path.expand(paths), winslash = "/", mustWork = FALSE)
+}
+
+quickr_makefiles_signature <- function() {
+  paths <- quickr_makefiles_paths()
+  if (!length(paths)) {
+    return("")
+  }
+
+  paste(vapply(paths, quickr_file_signature, character(1)), collapse = "\r")
+}
+
 quickr_toolchain_env_signature <- function() {
   vars <- c(
     "PATH",
@@ -694,6 +714,7 @@ quickr_toolchain_env_signature <- function() {
     "LDFLAGS",
     "LIBS",
     "MAKE",
+    "MAKEFILES",
     "R_MAKEVARS_SITE",
     "R_MAKEVARS_USER"
   )
@@ -703,6 +724,7 @@ quickr_toolchain_env_signature <- function() {
       paste(names(env), env, sep = "="),
       paste("MAKEVARS", quickr_makevars_signature(), sep = "="),
       paste("MAKEVARS_ENV", quickr_makevars_env_signature(), sep = "="),
+      paste("MAKEFILES_FILES", quickr_makefiles_signature(), sep = "="),
       paste("MAKECONF", quickr_makeconf_signature(), sep = "=")
     ),
     collapse = "\r"

--- a/R/aaa-utils.R
+++ b/R/aaa-utils.R
@@ -90,12 +90,17 @@ quickr_makevars_paths <- function() {
   user_paths <- if (!is.na(user_makevars) && nzchar(user_makevars)) {
     user_makevars
   } else {
-    user_root <- Sys.getenv("R_USER", unset = "")
-    if (!nzchar(user_root)) {
-      user_root <- Sys.getenv("HOME", unset = "")
-    }
-    if (nzchar(user_root)) {
-      file.path(user_root, ".R", quickr_default_makevars_names())
+    user_roots <- unique(c(
+      Sys.getenv("HOME", unset = ""),
+      Sys.getenv("R_USER", unset = "")
+    ))
+    user_roots <- user_roots[nzchar(user_roots)]
+    if (length(user_roots)) {
+      as.vector(outer(
+        user_roots,
+        file.path(".R", quickr_default_makevars_names()),
+        file.path
+      ))
     } else {
       character()
     }

--- a/R/aaa-utils.R
+++ b/R/aaa-utils.R
@@ -690,8 +690,14 @@ quickr_file_has_makevars_uncached_function <- function(path) {
   lines <- readLines(path, warn = FALSE)
   function_pattern <- "\\$\\([A-Za-z_][A-Za-z0-9_.-]*[[:space:]]|\\$\\{[A-Za-z_][A-Za-z0-9_.-]*[[:space:]]"
   substitution_pattern <- "\\$\\([A-Za-z_][A-Za-z0-9_.-]*:[^)]*\\)|\\$\\{[A-Za-z_][A-Za-z0-9_.-]*:[^}]*\\}"
+  shell_assignment_pattern <- "^[[:space:]]*(?:(?:export|override|private)[[:space:]]+)*[A-Za-z_][A-Za-z0-9_.-]*[[:space:]]*!="
   any(grepl(
-    paste(function_pattern, substitution_pattern, sep = "|"),
+    paste(
+      function_pattern,
+      substitution_pattern,
+      shell_assignment_pattern,
+      sep = "|"
+    ),
     lines,
     perl = TRUE
   ))
@@ -749,13 +755,21 @@ quickr_makevars_text_variable_refs <- function(text) {
 
 quickr_makevars_env_value <- function(name) {
   if (identical(name, "R_HOME")) {
-    return(R.home())
+    return(paste0("set:", R.home()))
   }
   if (identical(name, "CURDIR")) {
-    return(normalizePath(getwd(), winslash = "/", mustWork = TRUE))
+    return(paste0(
+      "set:",
+      normalizePath(getwd(), winslash = "/", mustWork = TRUE)
+    ))
   }
 
-  Sys.getenv(name, unset = "")
+  value <- Sys.getenv(name, unset = NA_character_)
+  if (is.na(value)) {
+    return("unset:")
+  }
+
+  paste0("set:", value)
 }
 
 quickr_makeconf_paths <- function(config_name = "") {

--- a/R/aaa-utils.R
+++ b/R/aaa-utils.R
@@ -240,14 +240,22 @@ quickr_makevars_scan_one_include_path <- function(path, variables, visited) {
   out <- character()
   vars <- variables
   conditional_stack <- list()
+  in_define <- FALSE
 
   for (line in lines) {
-    if (startsWith(line, "\t")) {
+    if (startsWith(line, "\t") && !in_define) {
       next
     }
 
     line <- trimws(quickr_strip_make_comment(line))
     if (!nzchar(line)) {
+      next
+    }
+
+    if (in_define) {
+      if (quickr_makevars_define_end(line)) {
+        in_define <- FALSE
+      }
       next
     }
 
@@ -262,6 +270,11 @@ quickr_makevars_scan_one_include_path <- function(path, variables, visited) {
     }
 
     if (!quickr_makevars_conditionals_active(conditional_stack)) {
+      next
+    }
+
+    if (quickr_makevars_define_start(line)) {
+      in_define <- TRUE
       next
     }
 
@@ -285,6 +298,18 @@ quickr_makevars_scan_one_include_path <- function(path, variables, visited) {
   }
 
   list(paths = out, variables = vars)
+}
+
+quickr_makevars_define_start <- function(line) {
+  grepl(
+    "^(?:(?:export|override)[[:space:]]+)*define(?:[[:space:]]|$)",
+    line,
+    perl = TRUE
+  )
+}
+
+quickr_makevars_define_end <- function(line) {
+  identical(line, "endef")
 }
 
 quickr_makevars_update_conditionals <- function(line, variables, stack) {

--- a/R/aaa-utils.R
+++ b/R/aaa-utils.R
@@ -591,20 +591,20 @@ quickr_makevars_env_signature <- function() {
   paste(paste(names(values), values, sep = "="), collapse = "\r")
 }
 
-quickr_makevars_has_shell_functions <- function() {
+quickr_makevars_has_uncached_functions <- function() {
   paths <- quickr_active_makevars_all_paths()
   paths <- paths[vapply(paths, quickr_regular_file_exists, logical(1))]
   if (!length(paths)) {
     return(FALSE)
   }
 
-  any(vapply(paths, quickr_file_has_makevars_shell_function, logical(1)))
+  any(vapply(paths, quickr_file_has_makevars_uncached_function, logical(1)))
 }
 
-quickr_file_has_makevars_shell_function <- function(path) {
+quickr_file_has_makevars_uncached_function <- function(path) {
   lines <- readLines(path, warn = FALSE)
   any(grepl(
-    "\\$\\(shell[[:space:]]|\\$\\{shell[[:space:]]",
+    "\\$\\((shell|wildcard)[[:space:]]|\\$\\{(shell|wildcard)[[:space:]]",
     lines,
     perl = TRUE
   ))
@@ -614,7 +614,32 @@ quickr_makevars_variable_refs <- function(path) {
   lines <- readLines(path, warn = FALSE)
   lines <- quickr_join_makevars_continuations(lines)
   lines <- vapply(lines, quickr_strip_make_comment, character(1))
-  quickr_makevars_text_variable_refs(paste(lines, collapse = "\n"))
+  unique(c(
+    quickr_makevars_text_variable_refs(paste(lines, collapse = "\n")),
+    quickr_makevars_conditional_variable_refs(lines)
+  ))
+}
+
+quickr_makevars_conditional_variable_refs <- function(lines) {
+  lines <- trimws(lines)
+  refs <- unlist(
+    lapply(lines, \(line) {
+      match <- regexec(
+        "^(?:else[[:space:]]+)?(?:ifdef|ifndef)[[:space:]]+([A-Za-z_][A-Za-z0-9_.-]*)$",
+        line,
+        perl = TRUE
+      )
+      parts <- regmatches(line, match)[[1]]
+      if (length(parts) == 2L) {
+        parts[[2]]
+      } else {
+        character()
+      }
+    }),
+    use.names = FALSE
+  )
+
+  unique(refs)
 }
 
 quickr_makevars_text_variable_refs <- function(text) {
@@ -694,7 +719,7 @@ quickr_cached_r_cmd_config_value <- function(
 ) {
   stopifnot(is_string(name), is.environment(cache))
 
-  if (quickr_makevars_has_shell_functions()) {
+  if (quickr_makevars_has_uncached_functions()) {
     return(quickr_r_cmd_config_probe(name)$value)
   }
 

--- a/R/aaa-utils.R
+++ b/R/aaa-utils.R
@@ -57,16 +57,19 @@ quickr_r_cmd <- function(
 quickr_compiler_probe_cache <- new.env(parent = emptyenv())
 
 quickr_default_makevars_names <- function(
-  platform = Sys.getenv("R_PLATFORM", unset = R.version$platform)
+  platform = Sys.getenv("R_PLATFORM", unset = R.version$platform),
+  os_type = Sys.getenv("R_OSTYPE", unset = .Platform$OS.type)
 ) {
-  unique(c(
-    paste0("Makevars-", platform),
-    "Makevars.ucrt",
-    "Makevars.win64",
-    "Makevars.win32",
-    "Makevars.win",
-    "Makevars"
-  ))
+  if (identical(os_type, "windows")) {
+    return(c(
+      "Makevars.ucrt",
+      "Makevars.win64",
+      "Makevars.win",
+      "Makevars"
+    ))
+  }
+
+  c(paste0("Makevars-", platform), "Makevars")
 }
 
 quickr_r_etc_path <- function(
@@ -91,20 +94,12 @@ quickr_regular_file_exists <- function(path) {
 }
 
 quickr_default_user_makevars_paths <- function() {
-  user_roots <- unique(c(
-    Sys.getenv("HOME", unset = ""),
-    Sys.getenv("R_USER", unset = "")
-  ))
-  user_roots <- user_roots[nzchar(user_roots)]
-  if (!length(user_roots)) {
+  home <- Sys.getenv("HOME", unset = "")
+  if (!nzchar(home)) {
     return(character())
   }
 
-  as.vector(outer(
-    user_roots,
-    file.path(".R", quickr_default_makevars_names()),
-    file.path
-  ))
+  file.path(home, ".R", quickr_default_makevars_names())
 }
 
 quickr_makevars_paths <- function() {
@@ -127,6 +122,42 @@ quickr_makevars_paths <- function() {
   }
 
   unique(c(site_paths, user_paths))
+}
+
+quickr_first_existing_file <- function(paths) {
+  paths <- paths[vapply(paths, quickr_regular_file_exists, logical(1))]
+  if (!length(paths)) {
+    return(character())
+  }
+
+  paths[[1]]
+}
+
+quickr_active_makevars_paths <- function() {
+  site_makevars <- Sys.getenv("R_MAKEVARS_SITE", unset = NA_character_)
+  site_path <- if (!is.na(site_makevars) && nzchar(site_makevars)) {
+    site_makevars
+  } else {
+    quickr_default_site_makevars_path()
+  }
+  site_path <- if (quickr_regular_file_exists(site_path)) {
+    site_path
+  } else {
+    character()
+  }
+
+  user_makevars <- Sys.getenv("R_MAKEVARS_USER", unset = NA_character_)
+  user_path <- if (
+    !is.na(user_makevars) &&
+      nzchar(user_makevars) &&
+      quickr_regular_file_exists(user_makevars)
+  ) {
+    user_makevars
+  } else {
+    quickr_first_existing_file(quickr_default_user_makevars_paths())
+  }
+
+  unique(c(site_path, user_path))
 }
 
 quickr_file_signature <- function(path) {
@@ -401,6 +432,16 @@ quickr_expand_makevars_include_globs <- function(paths) {
 
 quickr_makevars_all_paths <- function() {
   paths <- quickr_makevars_paths()
+  active_paths <- quickr_active_makevars_paths()
+  if (!length(paths) && !length(active_paths)) {
+    return(character())
+  }
+
+  unique(c(paths, quickr_makevars_include_paths(active_paths)))
+}
+
+quickr_active_makevars_all_paths <- function() {
+  paths <- quickr_active_makevars_paths()
   if (!length(paths)) {
     return(character())
   }
@@ -417,7 +458,7 @@ quickr_makevars_signature <- function() {
 }
 
 quickr_makevars_env_signature <- function() {
-  paths <- quickr_makevars_all_paths()
+  paths <- quickr_active_makevars_all_paths()
   paths <- paths[vapply(paths, quickr_regular_file_exists, logical(1))]
   if (!length(paths)) {
     return("")

--- a/R/aaa-utils.R
+++ b/R/aaa-utils.R
@@ -627,7 +627,8 @@ quickr_makevars_signature <- function(config_name = "") {
 quickr_makevars_env_signature <- function(config_name = "") {
   paths <- unique(c(
     quickr_active_makevars_all_paths(config_name),
-    quickr_makefiles_all_paths(config_name)
+    quickr_makefiles_all_paths(config_name),
+    quickr_makeconf_paths(config_name)
   ))
   paths <- paths[vapply(paths, quickr_regular_file_exists, logical(1))]
   if (!length(paths)) {
@@ -649,7 +650,8 @@ quickr_makevars_env_signature <- function(config_name = "") {
 quickr_makevars_has_uncached_functions <- function(config_name = "") {
   paths <- unique(c(
     quickr_active_makevars_all_paths(config_name),
-    quickr_makefiles_all_paths(config_name)
+    quickr_makefiles_all_paths(config_name),
+    quickr_makeconf_paths(config_name)
   ))
   paths <- paths[vapply(paths, quickr_regular_file_exists, logical(1))]
   if (!length(paths)) {

--- a/R/aaa-utils.R
+++ b/R/aaa-utils.R
@@ -548,7 +548,7 @@ quickr_strip_make_comment <- function(line) {
 quickr_expand_makevars_variables <- function(text, variables) {
   for (i in seq_len(20L)) {
     match <- regexpr(
-      "\\$\\(([A-Za-z_][A-Za-z0-9_.-]*)\\)|\\$\\{([A-Za-z_][A-Za-z0-9_.-]*)\\}",
+      "\\$\\(([A-Za-z_][A-Za-z0-9_.-]*)\\)|\\$\\{([A-Za-z_][A-Za-z0-9_.-]*)\\}|\\$([A-Za-z_])",
       text,
       perl = TRUE
     )
@@ -557,12 +557,24 @@ quickr_expand_makevars_variables <- function(text, variables) {
     }
 
     token <- regmatches(text, match)
-    name <- sub("^\\$[({]([A-Za-z_][A-Za-z0-9_.-]*)[)}]$", "\\1", token)
+    name <- quickr_makevars_variable_token_name(token)
     value <- quickr_makevars_variable_value(name, variables)
     regmatches(text, match) <- value
   }
 
   text
+}
+
+quickr_makevars_variable_token_name <- function(token) {
+  if (grepl("^\\$[({]", token)) {
+    return(sub(
+      "^\\$[({]([A-Za-z_][A-Za-z0-9_.-]*)[)}]$",
+      "\\1",
+      token
+    ))
+  }
+
+  substring(token, 2L)
 }
 
 quickr_expand_makevars_wildcard_functions <- function(text) {
@@ -764,7 +776,7 @@ quickr_makevars_conditional_variable_refs <- function(lines) {
 
 quickr_makevars_text_variable_refs <- function(text) {
   matches <- gregexpr(
-    "\\$\\(([A-Za-z_][A-Za-z0-9_.-]*)\\)|\\$\\{([A-Za-z_][A-Za-z0-9_.-]*)\\}",
+    "\\$\\(([A-Za-z_][A-Za-z0-9_.-]*)\\)|\\$\\{([A-Za-z_][A-Za-z0-9_.-]*)\\}|\\$([A-Za-z_])",
     text,
     perl = TRUE
   )
@@ -773,11 +785,7 @@ quickr_makevars_text_variable_refs <- function(text) {
     return(character())
   }
 
-  unique(sub(
-    "^\\$[({]([A-Za-z_][A-Za-z0-9_.-]*)[)}]$",
-    "\\1",
-    tokens
-  ))
+  unique(vapply(tokens, quickr_makevars_variable_token_name, character(1)))
 }
 
 quickr_makevars_env_value <- function(name) {

--- a/R/aaa-utils.R
+++ b/R/aaa-utils.R
@@ -141,50 +141,65 @@ quickr_file_signature <- function(path) {
 }
 
 quickr_makevars_include_paths <- function(paths) {
-  quickr_makevars_include_paths_impl(
+  scan <- quickr_makevars_scan_include_paths(
     normalizePath(paths, winslash = "/", mustWork = FALSE),
+    variables = character(),
     visited = character()
   )
+  scan$paths
 }
 
-quickr_makevars_include_paths_impl <- function(paths, visited) {
+quickr_makevars_scan_include_paths <- function(paths, variables, visited) {
   paths <- unique(normalizePath(paths, winslash = "/", mustWork = FALSE))
-  paths <- setdiff(paths, visited)
   out <- character()
+  vars <- variables
 
   for (path in paths) {
-    if (!quickr_regular_file_exists(path)) {
+    scan <- quickr_makevars_scan_one_include_path(path, vars, visited)
+    out <- unique(c(out, scan$paths))
+    vars <- scan$variables
+  }
+
+  list(paths = out, variables = vars)
+}
+
+quickr_makevars_scan_one_include_path <- function(path, variables, visited) {
+  path <- normalizePath(path, winslash = "/", mustWork = FALSE)
+  if (path %in% visited || !quickr_regular_file_exists(path)) {
+    return(list(paths = character(), variables = variables))
+  }
+
+  lines <- readLines(path, warn = FALSE)
+  lines <- quickr_join_makevars_continuations(lines)
+  out <- character()
+  vars <- variables
+
+  for (line in lines) {
+    line <- trimws(quickr_strip_make_comment(line))
+    if (!nzchar(line)) {
       next
     }
 
-    included <- quickr_makevars_direct_include_paths(path)
+    assignment <- quickr_makevars_assignment(line)
+    if (!is.null(assignment)) {
+      vars <- quickr_makevars_apply_assignment(vars, assignment)
+      next
+    }
+
+    included <- quickr_makevars_include_paths_from_line(line, vars, path)
     out <- unique(c(out, included))
     if (length(included)) {
-      out <- unique(c(
-        out,
-        quickr_makevars_include_paths_impl(included, c(visited, path))
-      ))
+      scan <- quickr_makevars_scan_include_paths(
+        included,
+        vars,
+        c(visited, path)
+      )
+      out <- unique(c(out, scan$paths))
+      vars <- scan$variables
     }
   }
 
-  out
-}
-
-quickr_makevars_direct_include_paths <- function(path) {
-  lines <- readLines(path, warn = FALSE)
-  lines <- quickr_join_makevars_continuations(lines)
-  variables <- quickr_makevars_variable_map(lines)
-  include_paths <- unlist(
-    lapply(
-      lines,
-      quickr_makevars_line_include_paths,
-      variables = variables,
-      makevars_path = path
-    ),
-    use.names = FALSE
-  )
-
-  unique(include_paths)
+  list(paths = out, variables = vars)
 }
 
 quickr_join_makevars_continuations <- function(lines) {
@@ -212,30 +227,41 @@ quickr_join_makevars_continuations <- function(lines) {
   out
 }
 
-quickr_makevars_variable_map <- function(lines) {
-  lines <- trimws(vapply(lines, quickr_strip_make_comment, character(1)))
-  assignments <- regexec(
-    "^([A-Za-z_][A-Za-z0-9_.-]*)[[:space:]]*[:?+]?=[[:space:]]*(.*)$",
-    lines,
+quickr_makevars_assignment <- function(line) {
+  match <- regexec(
+    "^([A-Za-z_][A-Za-z0-9_.-]*)[[:space:]]*([:?+]?=)[[:space:]]*(.*)$",
+    line,
     perl = TRUE
   )
-  matches <- regmatches(lines, assignments)
-  matches <- matches[lengths(matches) == 3L]
-  if (!length(matches)) {
-    return(character())
+  parts <- regmatches(line, match)[[1]]
+  if (length(parts) != 4L) {
+    return(NULL)
   }
 
-  values <- vapply(matches, `[[`, character(1), 3L)
-  names(values) <- vapply(matches, `[[`, character(1), 2L)
-  values
+  list(name = parts[[2]], operator = parts[[3]], value = parts[[4]])
 }
 
-quickr_makevars_line_include_paths <- function(
+quickr_makevars_apply_assignment <- function(variables, assignment) {
+  name <- assignment$name
+  value <- assignment$value
+
+  if (identical(assignment$operator, "?=") && name %in% names(variables)) {
+    return(variables)
+  }
+
+  if (identical(assignment$operator, "+=") && name %in% names(variables)) {
+    value <- paste(variables[[name]], value)
+  }
+
+  variables[[name]] <- value
+  variables
+}
+
+quickr_makevars_include_paths_from_line <- function(
   line,
   variables,
   makevars_path
 ) {
-  line <- trimws(quickr_strip_make_comment(line))
   match <- regexec(
     "^(-?include|sinclude)[[:space:]]+(.+)$",
     line,
@@ -288,6 +314,9 @@ quickr_makevars_variable_value <- function(name, variables) {
 
   if (identical(name, "R_HOME")) {
     return(R.home())
+  }
+  if (identical(name, "CURDIR")) {
+    return(normalizePath(getwd(), winslash = "/", mustWork = TRUE))
   }
 
   Sys.getenv(name, unset = "")
@@ -386,6 +415,9 @@ quickr_makevars_env_value <- function(name) {
   if (identical(name, "R_HOME")) {
     return(R.home())
   }
+  if (identical(name, "CURDIR")) {
+    return(normalizePath(getwd(), winslash = "/", mustWork = TRUE))
+  }
 
   Sys.getenv(name, unset = "")
 }
@@ -419,6 +451,11 @@ quickr_toolchain_env_signature <- function() {
   paste(
     c(
       paste(names(env), env, sep = "="),
+      paste(
+        "WD",
+        normalizePath(getwd(), winslash = "/", mustWork = TRUE),
+        sep = "="
+      ),
       paste("MAKEVARS", quickr_makevars_signature(), sep = "="),
       paste("MAKEVARS_ENV", quickr_makevars_env_signature(), sep = "="),
       paste("MAKECONF", quickr_makeconf_signature(), sep = "=")

--- a/R/aaa-utils.R
+++ b/R/aaa-utils.R
@@ -176,7 +176,9 @@ quickr_makevars_seed_variables <- function(config_name = "") {
     return(character())
   }
 
-  c(VAR = config_name)
+  variables <- c(VAR = config_name)
+  attr(variables, "quickr_command_line_variables") <- "VAR"
+  variables
 }
 
 quickr_makeconf_variables <- function(config_name = "") {
@@ -240,6 +242,10 @@ quickr_makevars_scan_one_include_path <- function(path, variables, visited) {
   conditional_stack <- list()
 
   for (line in lines) {
+    if (startsWith(line, "\t")) {
+      next
+    }
+
     line <- trimws(quickr_strip_make_comment(line))
     if (!nzchar(line)) {
       next
@@ -408,21 +414,34 @@ quickr_join_makevars_continuations <- function(lines) {
 
 quickr_makevars_assignment <- function(line) {
   match <- regexec(
-    "^(?:(?:export|override|private)[[:space:]]+)*([A-Za-z_][A-Za-z0-9_.-]*)[[:space:]]*([:?+]?=)[[:space:]]*(.*)$",
+    "^((?:(?:export|override|private)[[:space:]]+)*)?([A-Za-z_][A-Za-z0-9_.-]*)[[:space:]]*([:?+]?=)[[:space:]]*(.*)$",
     line,
     perl = TRUE
   )
   parts <- regmatches(line, match)[[1]]
-  if (length(parts) != 4L) {
+  if (length(parts) != 5L) {
     return(NULL)
   }
 
-  list(name = parts[[2]], operator = parts[[3]], value = parts[[4]])
+  list(
+    name = parts[[3]],
+    operator = parts[[4]],
+    value = parts[[5]],
+    override = grepl("(^|[[:space:]])override[[:space:]]+", parts[[2]])
+  )
 }
 
 quickr_makevars_apply_assignment <- function(variables, assignment) {
   name <- assignment$name
   value <- assignment$value
+
+  if (
+    name %in%
+      attr(variables, "quickr_command_line_variables", exact = TRUE) &&
+      !isTRUE(assignment$override)
+  ) {
+    return(variables)
+  }
 
   if (
     identical(assignment$operator, "?=") &&

--- a/R/aaa-utils.R
+++ b/R/aaa-utils.R
@@ -466,12 +466,19 @@ quickr_makevars_assignment <- function(line) {
 quickr_makevars_apply_assignment <- function(variables, assignment) {
   name <- assignment$name
   value <- assignment$value
+  command_line_variables <- attr(
+    variables,
+    "quickr_command_line_variables",
+    exact = TRUE
+  )
+  simple_variables <- attr(
+    variables,
+    "quickr_simple_variables",
+    exact = TRUE
+  ) %||%
+    character()
 
-  if (
-    name %in%
-      attr(variables, "quickr_command_line_variables", exact = TRUE) &&
-      !isTRUE(assignment$override)
-  ) {
+  if (name %in% command_line_variables && !isTRUE(assignment$override)) {
     return(variables)
   }
 
@@ -486,9 +493,15 @@ quickr_makevars_apply_assignment <- function(variables, assignment) {
 
   if (identical(assignment$operator, ":=")) {
     value <- quickr_expand_makevars_variables(value, variables)
+    simple_variables <- union(simple_variables, name)
+  } else if (!identical(assignment$operator, "+=")) {
+    simple_variables <- setdiff(simple_variables, name)
   }
 
   if (identical(assignment$operator, "+=")) {
+    if (name %in% simple_variables) {
+      value <- quickr_expand_makevars_variables(value, variables)
+    }
     old_value <- quickr_makevars_variable_value(name, variables)
     if (nzchar(old_value)) {
       value <- paste(old_value, value)
@@ -496,6 +509,8 @@ quickr_makevars_apply_assignment <- function(variables, assignment) {
   }
 
   variables[[name]] <- value
+  attr(variables, "quickr_command_line_variables") <- command_line_variables
+  attr(variables, "quickr_simple_variables") <- simple_variables
   variables
 }
 

--- a/R/aaa-utils.R
+++ b/R/aaa-utils.R
@@ -734,8 +734,7 @@ quickr_makevars_has_uncached_functions <- function(config_name = "") {
 
   paths <- unique(c(
     quickr_active_makevars_all_paths(config_name),
-    quickr_makefiles_all_paths(config_name),
-    quickr_makeconf_paths(config_name)
+    quickr_makefiles_all_paths(config_name)
   ))
   paths <- paths[vapply(paths, quickr_regular_file_exists, logical(1))]
   if (!length(paths)) {
@@ -760,6 +759,8 @@ quickr_makefiles_has_uncached_functions <- function(config_name = "") {
 
 quickr_file_has_makevars_uncached_function <- function(path) {
   lines <- readLines(path, warn = FALSE)
+  lines <- quickr_join_makevars_continuations(lines)
+  lines <- vapply(lines, quickr_strip_make_comment, character(1))
   quickr_text_has_makevars_uncached_function(lines)
 }
 

--- a/R/aaa-utils.R
+++ b/R/aaa-utils.R
@@ -749,7 +749,7 @@ quickr_text_has_makevars_uncached_function <- function(text) {
   function_pattern <- "\\$\\([A-Za-z_][A-Za-z0-9_.-]*[[:space:]]|\\$\\{[A-Za-z_][A-Za-z0-9_.-]*[[:space:]]"
   substitution_pattern <- "\\$\\([A-Za-z_][A-Za-z0-9_.-]*:[^)]*\\)|\\$\\{[A-Za-z_][A-Za-z0-9_.-]*:[^}]*\\}"
   shell_assignment_pattern <- "^[[:space:]]*(?:(?:export|override|private)[[:space:]]+)*[A-Za-z_][A-Za-z0-9_.-]*[[:space:]]*!="
-  indirect_ref_pattern <- "\\$[({]\\$[({]"
+  indirect_ref_pattern <- "\\$[({][^)}]*\\$[({]"
   any(grepl(
     paste(
       function_pattern,

--- a/R/aaa-utils.R
+++ b/R/aaa-utils.R
@@ -254,6 +254,10 @@ quickr_makevars_apply_assignment <- function(variables, assignment) {
     return(variables)
   }
 
+  if (identical(assignment$operator, ":=")) {
+    value <- quickr_expand_makevars_variables(value, variables)
+  }
+
   if (identical(assignment$operator, "+=") && name %in% names(variables)) {
     value <- paste(variables[[name]], value)
   }
@@ -329,14 +333,7 @@ quickr_makevars_variable_value <- function(name, variables) {
 
 quickr_resolve_makevars_include_path <- function(path, makevars_path) {
   path <- path.expand(path)
-  if (grepl("^(/|[A-Za-z]:[/\\\\])", path)) {
-    return(quickr_expand_makevars_include_globs(path))
-  }
-
-  quickr_expand_makevars_include_globs(unique(c(
-    path,
-    file.path(dirname(makevars_path), path)
-  )))
+  quickr_expand_makevars_include_globs(path)
 }
 
 quickr_expand_makevars_include_globs <- function(paths) {

--- a/R/aaa-utils.R
+++ b/R/aaa-utils.R
@@ -768,12 +768,14 @@ quickr_text_has_makevars_uncached_function <- function(text) {
   substitution_pattern <- "\\$\\([A-Za-z_][A-Za-z0-9_.-]*:[^)]*\\)|\\$\\{[A-Za-z_][A-Za-z0-9_.-]*:[^}]*\\}"
   shell_assignment_pattern <- "^[[:space:]]*(?:(?:export|override|private)[[:space:]]+)*[A-Za-z_][A-Za-z0-9_.-]*[[:space:]]*!="
   indirect_ref_pattern <- "\\$[({][^)}]*\\$[({]"
+  indirect_conditional_pattern <- "^[[:space:]]*(?:else[[:space:]]+)?ifn?def[[:space:]]+\\$[({]"
   any(grepl(
     paste(
       function_pattern,
       substitution_pattern,
       shell_assignment_pattern,
       indirect_ref_pattern,
+      indirect_conditional_pattern,
       sep = "|"
     ),
     text,

--- a/R/aaa-utils.R
+++ b/R/aaa-utils.R
@@ -204,10 +204,25 @@ quickr_makevars_scan_one_include_path <- function(path, variables, visited) {
   lines <- quickr_join_makevars_continuations(lines)
   out <- character()
   vars <- variables
+  conditional_stack <- list()
 
   for (line in lines) {
     line <- trimws(quickr_strip_make_comment(line))
     if (!nzchar(line)) {
+      next
+    }
+
+    conditional <- quickr_makevars_update_conditionals(
+      line,
+      vars,
+      conditional_stack
+    )
+    if (!is.null(conditional)) {
+      conditional_stack <- conditional
+      next
+    }
+
+    if (!quickr_makevars_conditionals_active(conditional_stack)) {
       next
     }
 
@@ -231,6 +246,93 @@ quickr_makevars_scan_one_include_path <- function(path, variables, visited) {
   }
 
   list(paths = out, variables = vars)
+}
+
+quickr_makevars_update_conditionals <- function(line, variables, stack) {
+  condition <- quickr_makevars_condition_result(line, variables)
+  if (!is.null(condition)) {
+    parent_active <- quickr_makevars_conditionals_active(stack)
+    stack[[length(stack) + 1L]] <- list(
+      parent_active = parent_active,
+      matched = condition,
+      active = parent_active && condition
+    )
+    return(stack)
+  }
+
+  if (grepl("^else([[:space:]]|$)", line)) {
+    if (!length(stack)) {
+      return(NULL)
+    }
+
+    rest <- trimws(sub("^else", "", line))
+    top <- stack[[length(stack)]]
+    condition <- if (nzchar(rest)) {
+      quickr_makevars_condition_result(rest, variables)
+    } else {
+      TRUE
+    }
+    if (is.null(condition)) {
+      condition <- TRUE
+    }
+    top$active <- top$parent_active && !top$matched && condition
+    top$matched <- top$matched || condition
+    stack[[length(stack)]] <- top
+    return(stack)
+  }
+
+  if (identical(line, "endif")) {
+    if (!length(stack)) {
+      return(NULL)
+    }
+
+    stack[[length(stack)]] <- NULL
+    return(stack)
+  }
+
+  NULL
+}
+
+quickr_makevars_conditionals_active <- function(stack) {
+  if (!length(stack)) {
+    return(TRUE)
+  }
+
+  isTRUE(stack[[length(stack)]]$active)
+}
+
+quickr_makevars_condition_result <- function(line, variables) {
+  match <- regexec(
+    "^(ifeq|ifneq)[[:space:]]*\\((.*),(.*)\\)$",
+    line,
+    perl = TRUE
+  )
+  parts <- regmatches(line, match)[[1]]
+  if (length(parts) == 4L) {
+    left <- quickr_makevars_condition_value(parts[[3]], variables)
+    right <- quickr_makevars_condition_value(parts[[4]], variables)
+    equal <- identical(left, right)
+    return(if (identical(parts[[2]], "ifeq")) equal else !equal)
+  }
+
+  match <- regexec(
+    "^(ifdef|ifndef)[[:space:]]+(.+)$",
+    line,
+    perl = TRUE
+  )
+  parts <- regmatches(line, match)[[1]]
+  if (length(parts) == 3L) {
+    value <- quickr_makevars_variable_value(trimws(parts[[3]]), variables)
+    defined <- nzchar(value)
+    return(if (identical(parts[[2]], "ifdef")) defined else !defined)
+  }
+
+  NULL
+}
+
+quickr_makevars_condition_value <- function(value, variables) {
+  value <- trimws(quickr_expand_makevars_variables(value, variables))
+  sub("^(['\"])(.*)\\1$", "\\2", value, perl = TRUE)
 }
 
 quickr_join_makevars_continuations <- function(lines) {

--- a/R/aaa-utils.R
+++ b/R/aaa-utils.R
@@ -57,7 +57,7 @@ quickr_r_cmd <- function(
 quickr_compiler_probe_cache <- new.env(parent = emptyenv())
 
 quickr_default_makevars_names <- function(
-  platform = R.version$platform
+  platform = Sys.getenv("R_PLATFORM", unset = R.version$platform)
 ) {
   unique(c(
     paste0("Makevars-", platform),
@@ -245,7 +245,12 @@ quickr_makevars_apply_assignment <- function(variables, assignment) {
   name <- assignment$name
   value <- assignment$value
 
-  if (identical(assignment$operator, "?=") && name %in% names(variables)) {
+  if (
+    identical(assignment$operator, "?=") &&
+      (name %in%
+        names(variables) ||
+        !is.na(Sys.getenv(name, unset = NA_character_)))
+  ) {
     return(variables)
   }
 
@@ -433,6 +438,7 @@ quickr_toolchain_env_signature <- function() {
     "HOME",
     "R_USER",
     "R_ARCH",
+    "R_PLATFORM",
     "CC",
     "CXX",
     "FC",

--- a/R/aaa-utils.R
+++ b/R/aaa-utils.R
@@ -399,7 +399,8 @@ quickr_makevars_condition_result <- function(line, variables) {
   )
   parts <- regmatches(line, match)[[1]]
   if (length(parts) == 3L) {
-    value <- quickr_makevars_variable_value(trimws(parts[[3]]), variables)
+    name <- quickr_makevars_condition_value(parts[[3]], variables)
+    value <- quickr_makevars_variable_value(name, variables)
     defined <- nzchar(value)
     return(if (identical(parts[[2]], "ifdef")) defined else !defined)
   }
@@ -481,8 +482,11 @@ quickr_makevars_apply_assignment <- function(variables, assignment) {
     value <- quickr_expand_makevars_variables(value, variables)
   }
 
-  if (identical(assignment$operator, "+=") && name %in% names(variables)) {
-    value <- paste(variables[[name]], value)
+  if (identical(assignment$operator, "+=")) {
+    old_value <- quickr_makevars_variable_value(name, variables)
+    if (nzchar(old_value)) {
+      value <- paste(old_value, value)
+    }
   }
 
   variables[[name]] <- value

--- a/R/aaa-utils.R
+++ b/R/aaa-utils.R
@@ -710,6 +710,10 @@ quickr_makevars_env_signature <- function(config_name = "") {
 }
 
 quickr_makevars_has_uncached_functions <- function(config_name = "") {
+  if (quickr_makefiles_has_uncached_functions(config_name)) {
+    return(TRUE)
+  }
+
   paths <- unique(c(
     quickr_active_makevars_all_paths(config_name),
     quickr_makefiles_all_paths(config_name),
@@ -723,8 +727,25 @@ quickr_makevars_has_uncached_functions <- function(config_name = "") {
   any(vapply(paths, quickr_file_has_makevars_uncached_function, logical(1)))
 }
 
+quickr_makefiles_has_uncached_functions <- function(config_name = "") {
+  makefiles <- Sys.getenv("MAKEFILES", unset = "")
+  if (!nzchar(makefiles)) {
+    return(FALSE)
+  }
+
+  makefiles <- quickr_expand_makevars_variables(
+    makefiles,
+    quickr_makevars_seed_variables(config_name)
+  )
+  quickr_text_has_makevars_uncached_function(makefiles)
+}
+
 quickr_file_has_makevars_uncached_function <- function(path) {
   lines <- readLines(path, warn = FALSE)
+  quickr_text_has_makevars_uncached_function(lines)
+}
+
+quickr_text_has_makevars_uncached_function <- function(text) {
   function_pattern <- "\\$\\([A-Za-z_][A-Za-z0-9_.-]*[[:space:]]|\\$\\{[A-Za-z_][A-Za-z0-9_.-]*[[:space:]]"
   substitution_pattern <- "\\$\\([A-Za-z_][A-Za-z0-9_.-]*:[^)]*\\)|\\$\\{[A-Za-z_][A-Za-z0-9_.-]*:[^}]*\\}"
   shell_assignment_pattern <- "^[[:space:]]*(?:(?:export|override|private)[[:space:]]+)*[A-Za-z_][A-Za-z0-9_.-]*[[:space:]]*!="
@@ -737,7 +758,7 @@ quickr_file_has_makevars_uncached_function <- function(path) {
       indirect_ref_pattern,
       sep = "|"
     ),
-    lines,
+    text,
     perl = TRUE
   ))
 }

--- a/R/aaa-utils.R
+++ b/R/aaa-utils.R
@@ -282,6 +282,7 @@ quickr_makevars_include_paths_from_line <- function(
   }
 
   spec <- quickr_expand_makevars_variables(parts[[3]], variables)
+  spec <- quickr_expand_makevars_wildcard_functions(spec)
   paths <- strsplit(trimws(spec), "[[:space:]]+")[[1]]
   paths <- paths[nzchar(paths)]
   paths <- unlist(
@@ -314,6 +315,52 @@ quickr_expand_makevars_variables <- function(text, variables) {
   }
 
   text
+}
+
+quickr_expand_makevars_wildcard_functions <- function(text) {
+  for (i in seq_len(20L)) {
+    match <- regexpr(
+      "\\$\\(wildcard[[:space:]]+([^()]*)\\)|\\$\\{wildcard[[:space:]]+([^{}]*)\\}",
+      text,
+      perl = TRUE
+    )
+    if (match[[1]] == -1L) {
+      break
+    }
+
+    token <- regmatches(text, match)
+    spec <- sub(
+      "^\\$\\(wildcard[[:space:]]+([^()]*)\\)$",
+      "\\1",
+      token,
+      perl = TRUE
+    )
+    if (identical(spec, token)) {
+      spec <- sub(
+        "^\\$\\{wildcard[[:space:]]+([^{}]*)\\}$",
+        "\\1",
+        token,
+        perl = TRUE
+      )
+    }
+    regmatches(text, match) <- quickr_makevars_wildcard_value(spec)
+  }
+
+  text
+}
+
+quickr_makevars_wildcard_value <- function(spec) {
+  paths <- strsplit(trimws(spec), "[[:space:]]+")[[1]]
+  paths <- paths[nzchar(paths)]
+  matches <- unlist(lapply(paths, Sys.glob), use.names = FALSE)
+  if (!length(matches)) {
+    return("")
+  }
+
+  paste(
+    normalizePath(matches, winslash = "/", mustWork = FALSE),
+    collapse = " "
+  )
 }
 
 quickr_makevars_variable_value <- function(name, variables) {

--- a/R/aaa-utils.R
+++ b/R/aaa-utils.R
@@ -172,14 +172,25 @@ quickr_file_signature <- function(path) {
 }
 
 quickr_makeconf_variables <- function() {
+  variables <- character()
+  makefiles <- quickr_makefiles_paths()
+  if (length(makefiles)) {
+    scan <- quickr_makevars_scan_include_paths(
+      makefiles,
+      variables = variables,
+      visited = character()
+    )
+    variables <- scan$variables
+  }
+
   path <- quickr_makeconf_path()
   if (!quickr_regular_file_exists(path)) {
-    return(character())
+    return(variables)
   }
 
   scan <- quickr_makevars_scan_include_paths(
     normalizePath(path, winslash = "/", mustWork = FALSE),
-    variables = character(),
+    variables = variables,
     visited = character()
   )
   scan$variables
@@ -617,8 +628,10 @@ quickr_makevars_has_uncached_functions <- function() {
 
 quickr_file_has_makevars_uncached_function <- function(path) {
   lines <- readLines(path, warn = FALSE)
+  function_pattern <- "\\$\\([A-Za-z_][A-Za-z0-9_.-]*[[:space:]]|\\$\\{[A-Za-z_][A-Za-z0-9_.-]*[[:space:]]"
+  substitution_pattern <- "\\$\\([A-Za-z_][A-Za-z0-9_.-]*:[^)]*\\)|\\$\\{[A-Za-z_][A-Za-z0-9_.-]*:[^}]*\\}"
   any(grepl(
-    "\\$\\([A-Za-z_][A-Za-z0-9_.-]*[[:space:]]|\\$\\{[A-Za-z_][A-Za-z0-9_.-]*[[:space:]]",
+    paste(function_pattern, substitution_pattern, sep = "|"),
     lines,
     perl = TRUE
   ))

--- a/R/aaa-utils.R
+++ b/R/aaa-utils.R
@@ -246,10 +246,11 @@ quickr_makevars_scan_one_include_path <- function(path, variables, visited) {
   out <- character()
   vars <- variables
   conditional_stack <- list()
-  in_define <- FALSE
+  define_assignment <- NULL
+  define_lines <- character()
 
   for (line in lines) {
-    if (startsWith(line, "\t") && !in_define) {
+    if (startsWith(line, "\t") && is.null(define_assignment)) {
       next
     }
 
@@ -258,9 +259,14 @@ quickr_makevars_scan_one_include_path <- function(path, variables, visited) {
       next
     }
 
-    if (in_define) {
+    if (!is.null(define_assignment)) {
       if (quickr_makevars_define_end(line)) {
-        in_define <- FALSE
+        define_assignment$value <- paste(define_lines, collapse = "\n")
+        vars <- quickr_makevars_apply_assignment(vars, define_assignment)
+        define_assignment <- NULL
+        define_lines <- character()
+      } else {
+        define_lines <- c(define_lines, line)
       }
       next
     }
@@ -279,8 +285,9 @@ quickr_makevars_scan_one_include_path <- function(path, variables, visited) {
       next
     }
 
-    if (quickr_makevars_define_start(line)) {
-      in_define <- TRUE
+    define_assignment <- quickr_makevars_define_assignment(line)
+    if (!is.null(define_assignment)) {
+      define_lines <- character()
       next
     }
 
@@ -306,11 +313,22 @@ quickr_makevars_scan_one_include_path <- function(path, variables, visited) {
   list(paths = out, variables = vars)
 }
 
-quickr_makevars_define_start <- function(line) {
-  grepl(
-    "^(?:(?:export|override)[[:space:]]+)*define(?:[[:space:]]|$)",
+quickr_makevars_define_assignment <- function(line) {
+  match <- regexec(
+    "^((?:(?:export|override)[[:space:]]+)*)?define[[:space:]]+([A-Za-z_][A-Za-z0-9_.-]*).*$",
     line,
     perl = TRUE
+  )
+  parts <- regmatches(line, match)[[1]]
+  if (length(parts) != 3L) {
+    return(NULL)
+  }
+
+  list(
+    name = parts[[3]],
+    operator = "=",
+    value = "",
+    override = grepl("(^|[[:space:]])override[[:space:]]+", parts[[2]])
   )
 }
 
@@ -373,7 +391,7 @@ quickr_makevars_conditionals_active <- function(stack) {
 
 quickr_makevars_condition_result <- function(line, variables) {
   match <- regexec(
-    "^(ifeq|ifneq)[[:space:]]*\\((.*),(.*)\\)$",
+    "^(ifeq|ifneq)[[:space:]]*\\((.*?),(.*)\\)$",
     line,
     perl = TRUE
   )

--- a/R/aaa-utils.R
+++ b/R/aaa-utils.R
@@ -375,7 +375,7 @@ quickr_join_makevars_continuations <- function(lines) {
 
 quickr_makevars_assignment <- function(line) {
   match <- regexec(
-    "^([A-Za-z_][A-Za-z0-9_.-]*)[[:space:]]*([:?+]?=)[[:space:]]*(.*)$",
+    "^(?:(?:export|override|private)[[:space:]]+)*([A-Za-z_][A-Za-z0-9_.-]*)[[:space:]]*([:?+]?=)[[:space:]]*(.*)$",
     line,
     perl = TRUE
   )
@@ -591,6 +591,25 @@ quickr_makevars_env_signature <- function() {
   paste(paste(names(values), values, sep = "="), collapse = "\r")
 }
 
+quickr_makevars_has_shell_functions <- function() {
+  paths <- quickr_active_makevars_all_paths()
+  paths <- paths[vapply(paths, quickr_regular_file_exists, logical(1))]
+  if (!length(paths)) {
+    return(FALSE)
+  }
+
+  any(vapply(paths, quickr_file_has_makevars_shell_function, logical(1)))
+}
+
+quickr_file_has_makevars_shell_function <- function(path) {
+  lines <- readLines(path, warn = FALSE)
+  any(grepl(
+    "\\$\\(shell[[:space:]]|\\$\\{shell[[:space:]]",
+    lines,
+    perl = TRUE
+  ))
+}
+
 quickr_makevars_variable_refs <- function(path) {
   lines <- readLines(path, warn = FALSE)
   lines <- quickr_join_makevars_continuations(lines)
@@ -674,6 +693,10 @@ quickr_cached_r_cmd_config_value <- function(
   cache = quickr_compiler_probe_cache
 ) {
   stopifnot(is_string(name), is.environment(cache))
+
+  if (quickr_makevars_has_shell_functions()) {
+    return(quickr_r_cmd_config_probe(name)$value)
+  }
 
   cache_key <- quickr_r_cmd_config_cache_key(name)
   cached <- get0(cache_key, envir = cache, inherits = FALSE, ifnotfound = NULL)

--- a/R/aaa-utils.R
+++ b/R/aaa-utils.R
@@ -126,7 +126,7 @@ quickr_makevars_paths <- function() {
     quickr_default_site_makevars_path()
   }
 
-  unique(c(user_paths, site_paths))
+  unique(c(site_paths, user_paths))
 }
 
 quickr_file_signature <- function(path) {
@@ -451,11 +451,6 @@ quickr_toolchain_env_signature <- function() {
   paste(
     c(
       paste(names(env), env, sep = "="),
-      paste(
-        "WD",
-        normalizePath(getwd(), winslash = "/", mustWork = TRUE),
-        sep = "="
-      ),
       paste("MAKEVARS", quickr_makevars_signature(), sep = "="),
       paste("MAKEVARS_ENV", quickr_makevars_env_signature(), sep = "="),
       paste("MAKECONF", quickr_makeconf_signature(), sep = "=")

--- a/R/compiler.R
+++ b/R/compiler.R
@@ -11,7 +11,12 @@ quickr_flang_path <- function() {
 }
 
 quickr_flang_available <- function() {
-  flang <- quickr_flang_path()
+  quickr_flang_available_at_path(quickr_flang_path())
+}
+
+quickr_flang_available_at_path <- function(flang) {
+  stopifnot(is_string(flang))
+
   if (!nzchar(flang)) {
     return(list(path = "", available = FALSE))
   }
@@ -23,6 +28,26 @@ quickr_flang_available <- function() {
     return(list(path = flang, available = FALSE))
   }
   list(path = flang, available = TRUE)
+}
+
+quickr_cached_flang_available <- function(
+  cache = quickr_compiler_probe_cache
+) {
+  stopifnot(is.environment(cache))
+
+  flang <- quickr_flang_path()
+  cache_key <- paste("flang_available", flang, sep = "\r")
+  cached <- get0(cache_key, envir = cache, inherits = FALSE, ifnotfound = NULL)
+  if (!is.null(cached)) {
+    return(cached)
+  }
+
+  cached <- quickr_flang_available_at_path(flang)
+  if (isTRUE(cached$available)) {
+    assign(cache_key, cached, envir = cache)
+  }
+
+  cached
 }
 
 quickr_flang_state <- local({
@@ -157,7 +182,7 @@ quickr_prefer_flang <- function(sysname = Sys.info()[["sysname"]]) {
 
   # Best-effort: on macOS, prefer flang if it is available.
   if (sysname == "Darwin") {
-    info <- quickr_flang_available()
+    info <- quickr_cached_flang_available()
     return(isTRUE(info$available))
   }
 
@@ -165,7 +190,7 @@ quickr_prefer_flang <- function(sysname = Sys.info()[["sysname"]]) {
 }
 
 quickr_default_fortran_makevars_lines <- function(
-  config_value = quickr_r_cmd_config_value
+  config_value = quickr_cached_r_cmd_config_value
 ) {
   fc <- trimws(config_value("FC"))
   if (!nzchar(fc)) {
@@ -191,7 +216,7 @@ quickr_fcompiler_env <- function(
   sysname = Sys.info()[["sysname"]],
   use_openmp = FALSE,
   link_flags = character(),
-  config_value = quickr_r_cmd_config_value
+  config_value = quickr_cached_r_cmd_config_value
 ) {
   stopifnot(is.character(build_dir), length(build_dir) == 1L, nzchar(build_dir))
 
@@ -204,7 +229,7 @@ quickr_fcompiler_env <- function(
   flang_runtime <- character()
   use_flang <- quickr_prefer_flang(sysname = sysname)
   if (use_flang) {
-    flang_info <- quickr_flang_available()
+    flang_info <- quickr_cached_flang_available()
     flang <- flang_info$path
     if (!isTRUE(flang_info$available)) {
       if (isTRUE(explicit_request)) {

--- a/R/quick.R
+++ b/R/quick.R
@@ -213,7 +213,7 @@ compile <- function(fsub, build_dir = tempfile(paste0(fsub@name, "-build-"))) {
 
   # Link against the same BLAS/LAPACK/Fortran libs as the running R
   # to support generated calls to vendor BLAS (e.g., dgemm, dgesv).
-  cfg <- quickr_r_cmd_config_value
+  cfg <- quickr_cached_r_cmd_config_value
   BLAS_LIBS <- strsplit(cfg("BLAS_LIBS"), "[[:space:]]+")[[1]]
   LAPACK_LIBS <- strsplit(cfg("LAPACK_LIBS"), "[[:space:]]+")[[1]]
   FLIBS <- strsplit(cfg("FLIBS"), "[[:space:]]+")[[1]]
@@ -327,7 +327,7 @@ compile <- function(fsub, build_dir = tempfile(paste0(fsub@name, "-build-"))) {
 quickr_windows_add_dll_paths <- function(
   flags,
   os_type = .Platform$OS.type,
-  config_value = quickr_r_cmd_config_value,
+  config_value = quickr_cached_r_cmd_config_value,
   which = Sys.which
 ) {
   if (!identical(os_type, "windows")) {

--- a/tests/testthat/test-compiler-cache.R
+++ b/tests/testthat/test-compiler-cache.R
@@ -150,6 +150,43 @@ test_that("quickr_cached_r_cmd_config_value keys on default HOME Makevars", {
   expect_equal(calls, 2L)
 })
 
+test_that("quickr_cached_r_cmd_config_value keys on platform Makevars", {
+  cache <- new.env(parent = emptyenv())
+  home <- withr::local_tempdir()
+  dir.create(file.path(home, ".R"))
+  makevars <- file.path(home, ".R", paste0("Makevars-", R.version$platform))
+  writeLines("FC=gfortran", makevars)
+  calls <- 0L
+  local_mocked_bindings(
+    quickr_r_cmd_config_probe = function(name) {
+      calls <<- calls + 1L
+      list(value = paste0("value-", calls), ok = TRUE)
+    },
+    .package = "quickr"
+  )
+  withr::local_envvar(c(
+    HOME = home,
+    R_USER = NA,
+    R_MAKEVARS_USER = NA
+  ))
+
+  expect_identical(
+    quickr:::quickr_cached_r_cmd_config_value("FC", cache = cache),
+    "value-1"
+  )
+  expect_identical(
+    quickr:::quickr_cached_r_cmd_config_value("FC", cache = cache),
+    "value-1"
+  )
+
+  writeLines("FC=flang", makevars)
+  expect_identical(
+    quickr:::quickr_cached_r_cmd_config_value("FC", cache = cache),
+    "value-2"
+  )
+  expect_equal(calls, 2L)
+})
+
 test_that("quickr_cached_flang_available reuses successful probes", {
   cache <- new.env(parent = emptyenv())
   calls <- 0L

--- a/tests/testthat/test-compiler-cache.R
+++ b/tests/testthat/test-compiler-cache.R
@@ -409,6 +409,47 @@ test_that("quickr_cached_r_cmd_config_value distinguishes unset and empty env re
   expect_equal(calls, 2L)
 })
 
+test_that("quickr_cached_r_cmd_config_value preserves env values for append assignments", {
+  cache <- new.env(parent = emptyenv())
+  root <- withr::local_tempdir()
+  makevars <- file.path(root, "Makevars")
+  env_include <- file.path(root, "env.mk")
+  local_include <- file.path(root, "local.mk")
+  writeLines(
+    c(
+      paste("INCLUDES +=", local_include),
+      "include $(INCLUDES)"
+    ),
+    makevars
+  )
+  writeLines("FC=gfortran", env_include)
+  writeLines("FFLAGS=-O2", local_include)
+  calls <- 0L
+  local_mocked_bindings(
+    quickr_r_cmd_config_probe = function(name) {
+      calls <<- calls + 1L
+      list(value = paste0("value-", calls), ok = TRUE)
+    },
+    .package = "quickr"
+  )
+  withr::local_envvar(c(
+    INCLUDES = env_include,
+    R_MAKEVARS_USER = makevars
+  ))
+
+  expect_identical(
+    quickr_cached_r_cmd_config_value("FC", cache = cache),
+    "value-1"
+  )
+
+  writeLines("FC=flang", env_include)
+  expect_identical(
+    quickr_cached_r_cmd_config_value("FC", cache = cache),
+    "value-2"
+  )
+  expect_equal(calls, 2L)
+})
+
 test_that("quickr_cached_r_cmd_config_value propagates variables through includes", {
   cache <- new.env(parent = emptyenv())
   root <- withr::local_tempdir()
@@ -899,6 +940,47 @@ test_that("quickr_cached_r_cmd_config_value keys on ifdef Makevars variables", {
   )
 
   withr::local_envvar(USE_A = NA)
+  expect_identical(
+    quickr_cached_r_cmd_config_value("FC", cache = cache),
+    "value-2"
+  )
+  expect_equal(calls, 2L)
+})
+
+test_that("quickr_cached_r_cmd_config_value expands ifdef variable names", {
+  cache <- new.env(parent = emptyenv())
+  root <- withr::local_tempdir()
+  active_root <- file.path(root, "active")
+  dir.create(active_root)
+  makevars <- file.path(root, "Makevars")
+  toolchain <- file.path(active_root, "toolchain.mk")
+  writeLines(
+    c(
+      "FLAG_NAME = USE_A",
+      "USE_A = 1",
+      "ifdef $(FLAG_NAME)",
+      paste("include", toolchain),
+      "endif"
+    ),
+    makevars
+  )
+  writeLines("FC=gfortran", toolchain)
+  calls <- 0L
+  local_mocked_bindings(
+    quickr_r_cmd_config_probe = function(name) {
+      calls <<- calls + 1L
+      list(value = paste0("value-", calls), ok = TRUE)
+    },
+    .package = "quickr"
+  )
+  withr::local_envvar(R_MAKEVARS_USER = makevars)
+
+  expect_identical(
+    quickr_cached_r_cmd_config_value("FC", cache = cache),
+    "value-1"
+  )
+
+  writeLines("FC=flang", toolchain)
   expect_identical(
     quickr_cached_r_cmd_config_value("FC", cache = cache),
     "value-2"

--- a/tests/testthat/test-compiler-cache.R
+++ b/tests/testthat/test-compiler-cache.R
@@ -372,6 +372,43 @@ test_that("quickr_cached_r_cmd_config_value respects env-defined conditional Mak
   expect_equal(calls, 2L)
 })
 
+test_that("quickr_cached_r_cmd_config_value distinguishes unset and empty env refs", {
+  cache <- new.env(parent = emptyenv())
+  root <- withr::local_tempdir()
+  makevars <- file.path(root, "Makevars")
+  writeLines(
+    c(
+      "MYFC ?= gfortran",
+      "override FC = $(MYFC)"
+    ),
+    makevars
+  )
+  calls <- 0L
+  local_mocked_bindings(
+    quickr_r_cmd_config_probe = function(name) {
+      calls <<- calls + 1L
+      list(value = paste0("value-", calls), ok = TRUE)
+    },
+    .package = "quickr"
+  )
+  withr::local_envvar(c(
+    MYFC = NA,
+    R_MAKEVARS_USER = makevars
+  ))
+
+  expect_identical(
+    quickr_cached_r_cmd_config_value("FC", cache = cache),
+    "value-1"
+  )
+
+  withr::local_envvar(MYFC = "")
+  expect_identical(
+    quickr_cached_r_cmd_config_value("FC", cache = cache),
+    "value-2"
+  )
+  expect_equal(calls, 2L)
+})
+
 test_that("quickr_cached_r_cmd_config_value propagates variables through includes", {
   cache <- new.env(parent = emptyenv())
   root <- withr::local_tempdir()
@@ -739,6 +776,36 @@ test_that("quickr_cached_r_cmd_config_value retries Makevars with shell function
   compiler_file <- file.path(root, "fc")
   writeLines("gfortran", compiler_file)
   writeLines(paste("FC = $(shell cat", compiler_file, ")"), makevars)
+  calls <- 0L
+  local_mocked_bindings(
+    quickr_r_cmd_config_probe = function(name) {
+      calls <<- calls + 1L
+      list(value = paste0("value-", calls), ok = TRUE)
+    },
+    .package = "quickr"
+  )
+  withr::local_envvar(R_MAKEVARS_USER = makevars)
+
+  expect_identical(
+    quickr_cached_r_cmd_config_value("FC", cache = cache),
+    "value-1"
+  )
+
+  writeLines("flang", compiler_file)
+  expect_identical(
+    quickr_cached_r_cmd_config_value("FC", cache = cache),
+    "value-2"
+  )
+  expect_equal(calls, 2L)
+})
+
+test_that("quickr_cached_r_cmd_config_value retries Makevars shell assignments", {
+  cache <- new.env(parent = emptyenv())
+  root <- withr::local_tempdir()
+  makevars <- file.path(root, "Makevars")
+  compiler_file <- file.path(root, "fc")
+  writeLines("gfortran", compiler_file)
+  writeLines(paste("FC != cat", compiler_file), makevars)
   calls <- 0L
   local_mocked_bindings(
     quickr_r_cmd_config_probe = function(name) {

--- a/tests/testthat/test-compiler-cache.R
+++ b/tests/testthat/test-compiler-cache.R
@@ -872,6 +872,58 @@ test_that("quickr_cached_r_cmd_config_value retries Makevars with wildcard assig
   expect_equal(calls, 2L)
 })
 
+test_that("quickr_cached_r_cmd_config_value retries Makevars with unresolved functions", {
+  cache <- new.env(parent = emptyenv())
+  makevars <- withr::local_tempfile()
+  writeLines("FC = $(abspath gfortran)", makevars)
+  calls <- 0L
+  local_mocked_bindings(
+    quickr_r_cmd_config_probe = function(name) {
+      calls <<- calls + 1L
+      list(value = paste0("value-", calls), ok = TRUE)
+    },
+    .package = "quickr"
+  )
+  withr::local_envvar(R_MAKEVARS_USER = makevars)
+
+  expect_identical(
+    quickr_cached_r_cmd_config_value("FC", cache = cache),
+    "value-1"
+  )
+  expect_identical(
+    quickr_cached_r_cmd_config_value("FC", cache = cache),
+    "value-2"
+  )
+  expect_equal(calls, 2L)
+})
+
+test_that("quickr_cached_r_cmd_config_value keys on MAKEFILES content", {
+  cache <- new.env(parent = emptyenv())
+  makefile <- withr::local_tempfile()
+  writeLines("FC=gfortran", makefile)
+  calls <- 0L
+  local_mocked_bindings(
+    quickr_r_cmd_config_probe = function(name) {
+      calls <<- calls + 1L
+      list(value = paste0("value-", calls), ok = TRUE)
+    },
+    .package = "quickr"
+  )
+  withr::local_envvar(MAKEFILES = makefile)
+
+  expect_identical(
+    quickr_cached_r_cmd_config_value("FC", cache = cache),
+    "value-1"
+  )
+
+  writeLines("FC=flang", makefile)
+  expect_identical(
+    quickr_cached_r_cmd_config_value("FC", cache = cache),
+    "value-2"
+  )
+  expect_equal(calls, 2L)
+})
+
 test_that("quickr_cached_r_cmd_config_value keys on default HOME Makevars", {
   cache <- new.env(parent = emptyenv())
   home_a <- withr::local_tempdir()

--- a/tests/testthat/test-compiler-cache.R
+++ b/tests/testthat/test-compiler-cache.R
@@ -1057,6 +1057,73 @@ test_that("quickr_cached_r_cmd_config_value seeds Makevars scan with Makeconf", 
   expect_equal(calls, 2L)
 })
 
+test_that("quickr_cached_r_cmd_config_value seeds Makevars scan with requested VAR", {
+  cache <- new.env(parent = emptyenv())
+  root <- withr::local_tempdir()
+  makevars <- file.path(root, "Makevars")
+  toolchain <- file.path(root, "fc.mk")
+  writeLines(
+    c(
+      "ifeq ($(VAR),FC)",
+      paste("include", toolchain),
+      "endif"
+    ),
+    makevars
+  )
+  writeLines("FC=gfortran", toolchain)
+  calls <- 0L
+  local_mocked_bindings(
+    quickr_r_cmd_config_probe = function(name) {
+      calls <<- calls + 1L
+      list(value = paste0("value-", calls), ok = TRUE)
+    },
+    .package = "quickr"
+  )
+  withr::local_envvar(R_MAKEVARS_USER = makevars)
+
+  expect_identical(
+    quickr_cached_r_cmd_config_value("FC", cache = cache),
+    "value-1"
+  )
+
+  writeLines("FC=flang", toolchain)
+  expect_identical(
+    quickr_cached_r_cmd_config_value("FC", cache = cache),
+    "value-2"
+  )
+  expect_equal(calls, 2L)
+})
+
+test_that("quickr_cached_r_cmd_config_value keys on Makeconf includes", {
+  cache <- new.env(parent = emptyenv())
+  root <- withr::local_tempdir()
+  makeconf <- file.path(root, "Makeconf")
+  nested <- file.path(root, "toolchain.mk")
+  writeLines(paste("include", nested), makeconf)
+  writeLines("FC=gfortran", nested)
+  calls <- 0L
+  local_mocked_bindings(
+    quickr_makeconf_path = function() makeconf,
+    quickr_r_cmd_config_probe = function(name) {
+      calls <<- calls + 1L
+      list(value = paste0("value-", calls), ok = TRUE)
+    },
+    .package = "quickr"
+  )
+
+  expect_identical(
+    quickr_cached_r_cmd_config_value("FC", cache = cache),
+    "value-1"
+  )
+
+  writeLines("FC=flang", nested)
+  expect_identical(
+    quickr_cached_r_cmd_config_value("FC", cache = cache),
+    "value-2"
+  )
+  expect_equal(calls, 2L)
+})
+
 test_that("quickr_cached_r_cmd_config_value seeds Makevars scan with MAKEFILES", {
   cache <- new.env(parent = emptyenv())
   root <- withr::local_tempdir()

--- a/tests/testthat/test-compiler-cache.R
+++ b/tests/testthat/test-compiler-cache.R
@@ -323,6 +323,55 @@ test_that("quickr_cached_r_cmd_config_value applies site variables before user i
   expect_equal(calls, 2L)
 })
 
+test_that("quickr_cached_r_cmd_config_value treats empty site Makevars as suppressed", {
+  cache <- new.env(parent = emptyenv())
+  root <- withr::local_tempdir()
+  active_root <- file.path(root, "active")
+  ignored_root <- file.path(root, "ignored")
+  dir.create(active_root)
+  dir.create(ignored_root)
+  site_makevars <- file.path(root, "Makevars.site")
+  user_makevars <- file.path(root, "Makevars")
+  active_toolchain <- file.path(active_root, "toolchain.mk")
+  ignored_toolchain <- file.path(ignored_root, "toolchain.mk")
+  writeLines(paste("DIR =", ignored_root), site_makevars)
+  writeLines("include $(DIR)/toolchain.mk", user_makevars)
+  writeLines("FC=gfortran", active_toolchain)
+  writeLines("FC=ignored", ignored_toolchain)
+  calls <- 0L
+  local_mocked_bindings(
+    quickr_default_site_makevars_path = function() site_makevars,
+    quickr_r_cmd_config_probe = function(name) {
+      calls <<- calls + 1L
+      list(value = paste0("value-", calls), ok = TRUE)
+    },
+    .package = "quickr"
+  )
+  withr::local_envvar(c(
+    DIR = active_root,
+    R_MAKEVARS_SITE = "",
+    R_MAKEVARS_USER = user_makevars
+  ))
+
+  expect_identical(
+    quickr_cached_r_cmd_config_value("FC", cache = cache),
+    "value-1"
+  )
+
+  writeLines("FC=still-ignored", ignored_toolchain)
+  expect_identical(
+    quickr_cached_r_cmd_config_value("FC", cache = cache),
+    "value-1"
+  )
+
+  writeLines("FC=flang", active_toolchain)
+  expect_identical(
+    quickr_cached_r_cmd_config_value("FC", cache = cache),
+    "value-2"
+  )
+  expect_equal(calls, 2L)
+})
+
 test_that("quickr_cached_r_cmd_config_value respects env-defined conditional Makevars variables", {
   cache <- new.env(parent = emptyenv())
   root <- withr::local_tempdir()
@@ -1456,6 +1505,45 @@ test_that("quickr_cached_r_cmd_config_value preserves command-line VAR", {
     "value-2"
   )
   expect_equal(calls, 2L)
+})
+
+test_that("quickr_cached_r_cmd_config_value preserves command-line R_HOME", {
+  cache <- new.env(parent = emptyenv())
+  root <- withr::local_tempdir()
+  ignored_root <- file.path(root, "ignored-r-home")
+  ignored_etc <- file.path(ignored_root, "etc")
+  dir.create(ignored_etc, recursive = TRUE)
+  makevars <- file.path(root, "Makevars")
+  ignored_toolchain <- file.path(ignored_etc, "toolchain.mk")
+  writeLines(
+    c(
+      paste("R_HOME =", ignored_root),
+      "include $(R_HOME)/etc/toolchain.mk"
+    ),
+    makevars
+  )
+  writeLines("FC=ignored", ignored_toolchain)
+  calls <- 0L
+  local_mocked_bindings(
+    quickr_r_cmd_config_probe = function(name) {
+      calls <<- calls + 1L
+      list(value = paste0("value-", calls), ok = TRUE)
+    },
+    .package = "quickr"
+  )
+  withr::local_envvar(R_MAKEVARS_USER = makevars)
+
+  expect_identical(
+    quickr_cached_r_cmd_config_value("FC", cache = cache),
+    "value-1"
+  )
+
+  writeLines("FC=still-ignored", ignored_toolchain)
+  expect_identical(
+    quickr_cached_r_cmd_config_value("FC", cache = cache),
+    "value-1"
+  )
+  expect_equal(calls, 1L)
 })
 
 test_that("quickr_cached_r_cmd_config_value seeds Makevars scan with MAKEFILES", {

--- a/tests/testthat/test-compiler-cache.R
+++ b/tests/testthat/test-compiler-cache.R
@@ -954,6 +954,66 @@ test_that("quickr_cached_r_cmd_config_value keys on nested MAKEFILES content", {
   expect_equal(calls, 2L)
 })
 
+test_that("quickr_cached_r_cmd_config_value keys on MAKEFILES env refs", {
+  cache <- new.env(parent = emptyenv())
+  makefile <- withr::local_tempfile()
+  writeLines("override FC = $(QUICKR_FC)", makefile)
+  calls <- 0L
+  local_mocked_bindings(
+    quickr_r_cmd_config_probe = function(name) {
+      calls <<- calls + 1L
+      list(value = paste0("value-", calls), ok = TRUE)
+    },
+    .package = "quickr"
+  )
+  withr::local_envvar(c(
+    MAKEFILES = makefile,
+    QUICKR_FC = "gfortran"
+  ))
+
+  expect_identical(
+    quickr_cached_r_cmd_config_value("FC", cache = cache),
+    "value-1"
+  )
+
+  withr::local_envvar(QUICKR_FC = "flang")
+  expect_identical(
+    quickr_cached_r_cmd_config_value("FC", cache = cache),
+    "value-2"
+  )
+  expect_equal(calls, 2L)
+})
+
+test_that("quickr_cached_r_cmd_config_value retries dynamic MAKEFILES inputs", {
+  cache <- new.env(parent = emptyenv())
+  root <- withr::local_tempdir()
+  makefile <- file.path(root, "global.mk")
+  compiler_file <- file.path(root, "fc")
+  writeLines("gfortran", compiler_file)
+  writeLines(paste("override FC = $(shell cat", compiler_file, ")"), makefile)
+  calls <- 0L
+  local_mocked_bindings(
+    quickr_r_cmd_config_probe = function(name) {
+      calls <<- calls + 1L
+      list(value = paste0("value-", calls), ok = TRUE)
+    },
+    .package = "quickr"
+  )
+  withr::local_envvar(MAKEFILES = makefile)
+
+  expect_identical(
+    quickr_cached_r_cmd_config_value("FC", cache = cache),
+    "value-1"
+  )
+
+  writeLines("flang", compiler_file)
+  expect_identical(
+    quickr_cached_r_cmd_config_value("FC", cache = cache),
+    "value-2"
+  )
+  expect_equal(calls, 2L)
+})
+
 test_that("quickr_cached_r_cmd_config_value seeds Makevars scan with Makeconf", {
   cache <- new.env(parent = emptyenv())
   root <- withr::local_tempdir()

--- a/tests/testthat/test-compiler-cache.R
+++ b/tests/testthat/test-compiler-cache.R
@@ -1641,7 +1641,39 @@ test_that("quickr_cached_r_cmd_config_value keys on Makeconf env refs", {
   expect_equal(calls, 2L)
 })
 
-test_that("quickr_cached_r_cmd_config_value retries dynamic Makeconf inputs", {
+test_that("quickr_cached_r_cmd_config_value caches Makeconf make functions", {
+  cache <- new.env(parent = emptyenv())
+  makeconf <- withr::local_tempfile()
+  writeLines(
+    c(
+      "USE_LLVM =",
+      "CCBASE = $(if $(USE_LLVM),clang,gcc)",
+      "FC = $(CCBASE)"
+    ),
+    makeconf
+  )
+  calls <- 0L
+  local_mocked_bindings(
+    quickr_makeconf_path = function() makeconf,
+    quickr_r_cmd_config_probe = function(name) {
+      calls <<- calls + 1L
+      list(value = paste0("value-", calls), ok = TRUE)
+    },
+    .package = "quickr"
+  )
+
+  expect_identical(
+    quickr_cached_r_cmd_config_value("FC", cache = cache),
+    "value-1"
+  )
+  expect_identical(
+    quickr_cached_r_cmd_config_value("FC", cache = cache),
+    "value-1"
+  )
+  expect_equal(calls, 1L)
+})
+
+test_that("quickr_cached_r_cmd_config_value keys on dynamic Makeconf content", {
   cache <- new.env(parent = emptyenv())
   root <- withr::local_tempdir()
   makeconf <- file.path(root, "Makeconf")
@@ -1664,6 +1696,15 @@ test_that("quickr_cached_r_cmd_config_value retries dynamic Makeconf inputs", {
   )
 
   writeLines("flang", compiler_file)
+  expect_identical(
+    quickr_cached_r_cmd_config_value("FC", cache = cache),
+    "value-1"
+  )
+
+  writeLines(
+    paste("FC = $(shell cat", compiler_file, ") # changed"),
+    makeconf
+  )
   expect_identical(
     quickr_cached_r_cmd_config_value("FC", cache = cache),
     "value-2"

--- a/tests/testthat/test-compiler-cache.R
+++ b/tests/testthat/test-compiler-cache.R
@@ -512,6 +512,41 @@ test_that("quickr_cached_r_cmd_config_value honors immediate Makevars assignment
   expect_equal(calls, 2L)
 })
 
+test_that("quickr_cached_r_cmd_config_value keys on wildcard Makevars includes", {
+  cache <- new.env(parent = emptyenv())
+  root <- withr::local_tempdir()
+  snippets <- file.path(root, "snippets")
+  dir.create(snippets)
+  makevars <- file.path(root, "Makevars")
+  toolchain <- file.path(snippets, "toolchain.mk")
+  writeLines(
+    paste0("include $(wildcard ", file.path(snippets, "*.mk"), ")"),
+    makevars
+  )
+  writeLines("FC=gfortran", toolchain)
+  calls <- 0L
+  local_mocked_bindings(
+    quickr_r_cmd_config_probe = function(name) {
+      calls <<- calls + 1L
+      list(value = paste0("value-", calls), ok = TRUE)
+    },
+    .package = "quickr"
+  )
+  withr::local_envvar(R_MAKEVARS_USER = makevars)
+
+  expect_identical(
+    quickr_cached_r_cmd_config_value("FC", cache = cache),
+    "value-1"
+  )
+
+  writeLines("FC=flang", toolchain)
+  expect_identical(
+    quickr_cached_r_cmd_config_value("FC", cache = cache),
+    "value-2"
+  )
+  expect_equal(calls, 2L)
+})
+
 test_that("quickr_cached_r_cmd_config_value keys on R_PLATFORM Makevars", {
   cache <- new.env(parent = emptyenv())
   home <- withr::local_tempdir()

--- a/tests/testthat/test-compiler-cache.R
+++ b/tests/testthat/test-compiler-cache.R
@@ -924,6 +924,36 @@ test_that("quickr_cached_r_cmd_config_value keys on MAKEFILES content", {
   expect_equal(calls, 2L)
 })
 
+test_that("quickr_cached_r_cmd_config_value keys on nested MAKEFILES content", {
+  cache <- new.env(parent = emptyenv())
+  root <- withr::local_tempdir()
+  makefile <- file.path(root, "top.mk")
+  nested <- file.path(root, "nested.mk")
+  writeLines(paste("include", nested), makefile)
+  writeLines("FC=gfortran", nested)
+  calls <- 0L
+  local_mocked_bindings(
+    quickr_r_cmd_config_probe = function(name) {
+      calls <<- calls + 1L
+      list(value = paste0("value-", calls), ok = TRUE)
+    },
+    .package = "quickr"
+  )
+  withr::local_envvar(MAKEFILES = makefile)
+
+  expect_identical(
+    quickr_cached_r_cmd_config_value("FC", cache = cache),
+    "value-1"
+  )
+
+  writeLines("FC=flang", nested)
+  expect_identical(
+    quickr_cached_r_cmd_config_value("FC", cache = cache),
+    "value-2"
+  )
+  expect_equal(calls, 2L)
+})
+
 test_that("quickr_cached_r_cmd_config_value keys on default HOME Makevars", {
   cache <- new.env(parent = emptyenv())
   home_a <- withr::local_tempdir()

--- a/tests/testthat/test-compiler-cache.R
+++ b/tests/testthat/test-compiler-cache.R
@@ -683,6 +683,55 @@ test_that("quickr_cached_r_cmd_config_value respects Makevars conditionals", {
   expect_equal(calls, 2L)
 })
 
+test_that("quickr_cached_r_cmd_config_value respects quoted Makevars conditionals", {
+  cache <- new.env(parent = emptyenv())
+  root <- withr::local_tempdir()
+  active_root <- file.path(root, "active")
+  inactive_root <- file.path(root, "inactive")
+  dir.create(active_root)
+  dir.create(inactive_root)
+  makevars <- file.path(root, "Makevars")
+  active_toolchain <- file.path(active_root, "toolchain.mk")
+  inactive_toolchain <- file.path(inactive_root, "toolchain.mk")
+  writeLines(
+    c(
+      "ifeq \"$(USE_A)\" \"1\"",
+      paste("ROOT =", active_root),
+      "else",
+      paste("ROOT =", inactive_root),
+      "endif",
+      "include $(ROOT)/toolchain.mk"
+    ),
+    makevars
+  )
+  writeLines("FC=gfortran", active_toolchain)
+  writeLines("FC=ignored", inactive_toolchain)
+  calls <- 0L
+  local_mocked_bindings(
+    quickr_r_cmd_config_probe = function(name) {
+      calls <<- calls + 1L
+      list(value = paste0("value-", calls), ok = TRUE)
+    },
+    .package = "quickr"
+  )
+  withr::local_envvar(c(
+    R_MAKEVARS_USER = makevars,
+    USE_A = "1"
+  ))
+
+  expect_identical(
+    quickr_cached_r_cmd_config_value("FC", cache = cache),
+    "value-1"
+  )
+
+  writeLines("FC=flang", active_toolchain)
+  expect_identical(
+    quickr_cached_r_cmd_config_value("FC", cache = cache),
+    "value-2"
+  )
+  expect_equal(calls, 2L)
+})
+
 test_that("quickr_cached_r_cmd_config_value keys on default HOME Makevars", {
   cache <- new.env(parent = emptyenv())
   home_a <- withr::local_tempdir()

--- a/tests/testthat/test-compiler-cache.R
+++ b/tests/testthat/test-compiler-cache.R
@@ -1095,6 +1095,42 @@ test_that("quickr_cached_r_cmd_config_value retries Makevars with unresolved fun
   expect_equal(calls, 2L)
 })
 
+test_that("quickr_cached_r_cmd_config_value retries Makevars with indirect refs", {
+  cache <- new.env(parent = emptyenv())
+  makevars <- withr::local_tempfile()
+  writeLines(
+    c(
+      "FC_VAR = QUICKR_FC",
+      "FC = $($(FC_VAR))"
+    ),
+    makevars
+  )
+  calls <- 0L
+  local_mocked_bindings(
+    quickr_r_cmd_config_probe = function(name) {
+      calls <<- calls + 1L
+      list(value = paste0("value-", calls), ok = TRUE)
+    },
+    .package = "quickr"
+  )
+  withr::local_envvar(c(
+    QUICKR_FC = "gfortran",
+    R_MAKEVARS_USER = makevars
+  ))
+
+  expect_identical(
+    quickr_cached_r_cmd_config_value("FC", cache = cache),
+    "value-1"
+  )
+
+  withr::local_envvar(QUICKR_FC = "flang")
+  expect_identical(
+    quickr_cached_r_cmd_config_value("FC", cache = cache),
+    "value-2"
+  )
+  expect_equal(calls, 2L)
+})
+
 test_that("quickr_cached_r_cmd_config_value keys on MAKEFILES content", {
   cache <- new.env(parent = emptyenv())
   makefile <- withr::local_tempfile()
@@ -1108,6 +1144,37 @@ test_that("quickr_cached_r_cmd_config_value keys on MAKEFILES content", {
     .package = "quickr"
   )
   withr::local_envvar(MAKEFILES = makefile)
+
+  expect_identical(
+    quickr_cached_r_cmd_config_value("FC", cache = cache),
+    "value-1"
+  )
+
+  writeLines("FC=flang", makefile)
+  expect_identical(
+    quickr_cached_r_cmd_config_value("FC", cache = cache),
+    "value-2"
+  )
+  expect_equal(calls, 2L)
+})
+
+test_that("quickr_cached_r_cmd_config_value expands MAKEFILES entries", {
+  cache <- new.env(parent = emptyenv())
+  root <- withr::local_tempdir()
+  makefile <- file.path(root, "global.mk")
+  writeLines("FC=gfortran", makefile)
+  calls <- 0L
+  local_mocked_bindings(
+    quickr_r_cmd_config_probe = function(name) {
+      calls <<- calls + 1L
+      list(value = paste0("value-", calls), ok = TRUE)
+    },
+    .package = "quickr"
+  )
+  withr::local_envvar(c(
+    MAKEFILES = "$(ROOT)/global.mk",
+    ROOT = root
+  ))
 
   expect_identical(
     quickr_cached_r_cmd_config_value("FC", cache = cache),

--- a/tests/testthat/test-compiler-cache.R
+++ b/tests/testthat/test-compiler-cache.R
@@ -586,6 +586,54 @@ test_that("quickr_cached_r_cmd_config_value keys on R_PLATFORM Makevars", {
   expect_equal(calls, 2L)
 })
 
+test_that("quickr_cached_r_cmd_config_value ignores inactive Makevars candidates", {
+  cache <- new.env(parent = emptyenv())
+  home <- withr::local_tempdir()
+  active_root <- file.path(home, "active")
+  ignored_root <- file.path(home, "ignored")
+  dir.create(file.path(home, ".R"))
+  dir.create(active_root)
+  dir.create(ignored_root)
+  makevars <- file.path(home, ".R", "Makevars")
+  ignored_makevars <- file.path(home, ".R", "Makevars.ucrt")
+  active_toolchain <- file.path(active_root, "toolchain.mk")
+  ignored_toolchain <- file.path(ignored_root, "toolchain.mk")
+  writeLines(paste("ROOT =", ignored_root), ignored_makevars)
+  writeLines(
+    c(
+      paste("ROOT ?=", active_root),
+      "include $(ROOT)/toolchain.mk"
+    ),
+    makevars
+  )
+  writeLines("FC=gfortran", active_toolchain)
+  writeLines("FC=ignored", ignored_toolchain)
+  calls <- 0L
+  local_mocked_bindings(
+    quickr_r_cmd_config_probe = function(name) {
+      calls <<- calls + 1L
+      list(value = paste0("value-", calls), ok = TRUE)
+    },
+    .package = "quickr"
+  )
+  withr::local_envvar(c(
+    HOME = home,
+    R_MAKEVARS_USER = NA
+  ))
+
+  expect_identical(
+    quickr_cached_r_cmd_config_value("FC", cache = cache),
+    "value-1"
+  )
+
+  writeLines("FC=flang", active_toolchain)
+  expect_identical(
+    quickr_cached_r_cmd_config_value("FC", cache = cache),
+    "value-2"
+  )
+  expect_equal(calls, 2L)
+})
+
 test_that("quickr_cached_r_cmd_config_value keys on default HOME Makevars", {
   cache <- new.env(parent = emptyenv())
   home_a <- withr::local_tempdir()

--- a/tests/testthat/test-compiler-cache.R
+++ b/tests/testthat/test-compiler-cache.R
@@ -220,6 +220,37 @@ test_that("quickr_cached_r_cmd_config_value keys on Makevars CURDIR", {
   expect_equal(calls, 2L)
 })
 
+test_that("quickr_cached_r_cmd_config_value ignores cwd without Makevars cwd dependencies", {
+  cache <- new.env(parent = emptyenv())
+  makevars <- withr::local_tempfile()
+  build_a <- withr::local_tempdir()
+  build_b <- withr::local_tempdir()
+  writeLines("FC=gfortran", makevars)
+  calls <- 0L
+  local_mocked_bindings(
+    quickr_r_cmd_config_probe = function(name) {
+      calls <<- calls + 1L
+      list(value = paste0("value-", calls), ok = TRUE)
+    },
+    .package = "quickr"
+  )
+  withr::local_envvar(R_MAKEVARS_USER = makevars)
+
+  withr::with_dir(build_a, {
+    expect_identical(
+      quickr_cached_r_cmd_config_value("FC", cache = cache),
+      "value-1"
+    )
+  })
+  withr::with_dir(build_b, {
+    expect_identical(
+      quickr_cached_r_cmd_config_value("FC", cache = cache),
+      "value-1"
+    )
+  })
+  expect_equal(calls, 1L)
+})
+
 test_that("quickr_cached_r_cmd_config_value keys on included Makevars content", {
   cache <- new.env(parent = emptyenv())
   makevars <- withr::local_tempfile()
@@ -246,6 +277,45 @@ test_that("quickr_cached_r_cmd_config_value keys on included Makevars content", 
   )
 
   writeLines("FC=flang", included)
+  expect_identical(
+    quickr_cached_r_cmd_config_value("FC", cache = cache),
+    "value-2"
+  )
+  expect_equal(calls, 2L)
+})
+
+test_that("quickr_cached_r_cmd_config_value applies site variables before user includes", {
+  cache <- new.env(parent = emptyenv())
+  root <- withr::local_tempdir()
+  site_makevars <- file.path(root, "Makevars.site")
+  user_makevars <- file.path(root, "Makevars")
+  nested <- file.path(root, "nested.mk")
+  writeLines(paste("DIR =", root), site_makevars)
+  writeLines("include $(DIR)/nested.mk", user_makevars)
+  writeLines("FC=gfortran", nested)
+  calls <- 0L
+  local_mocked_bindings(
+    quickr_r_cmd_config_probe = function(name) {
+      calls <<- calls + 1L
+      list(value = paste0("value-", calls), ok = TRUE)
+    },
+    .package = "quickr"
+  )
+  withr::local_envvar(c(
+    R_MAKEVARS_SITE = site_makevars,
+    R_MAKEVARS_USER = user_makevars
+  ))
+
+  expect_identical(
+    quickr_cached_r_cmd_config_value("FC", cache = cache),
+    "value-1"
+  )
+  expect_identical(
+    quickr_cached_r_cmd_config_value("FC", cache = cache),
+    "value-1"
+  )
+
+  writeLines("FC=flang", nested)
   expect_identical(
     quickr_cached_r_cmd_config_value("FC", cache = cache),
     "value-2"

--- a/tests/testthat/test-compiler-cache.R
+++ b/tests/testthat/test-compiler-cache.R
@@ -12,11 +12,11 @@ test_that("quickr_cached_r_cmd_config_value reuses successful lookups", {
   )
 
   expect_identical(
-    quickr:::quickr_cached_r_cmd_config_value("FC", cache = cache),
+    quickr_cached_r_cmd_config_value("FC", cache = cache),
     "FC-value-1"
   )
   expect_identical(
-    quickr:::quickr_cached_r_cmd_config_value("FC", cache = cache),
+    quickr_cached_r_cmd_config_value("FC", cache = cache),
     "FC-value-1"
   )
   expect_equal(calls, 1L)
@@ -37,15 +37,15 @@ test_that("quickr_cached_r_cmd_config_value retries failed lookups", {
   )
 
   expect_identical(
-    quickr:::quickr_cached_r_cmd_config_value("FC", cache = cache),
+    quickr_cached_r_cmd_config_value("FC", cache = cache),
     ""
   )
   expect_identical(
-    quickr:::quickr_cached_r_cmd_config_value("FC", cache = cache),
+    quickr_cached_r_cmd_config_value("FC", cache = cache),
     "gfortran"
   )
   expect_identical(
-    quickr:::quickr_cached_r_cmd_config_value("FC", cache = cache),
+    quickr_cached_r_cmd_config_value("FC", cache = cache),
     "gfortran"
   )
   expect_equal(calls, 2L)
@@ -64,21 +64,21 @@ test_that("quickr_cached_r_cmd_config_value keys on toolchain env", {
 
   withr::local_envvar(FC = "gfortran")
   expect_identical(
-    quickr:::quickr_cached_r_cmd_config_value("FC", cache = cache),
+    quickr_cached_r_cmd_config_value("FC", cache = cache),
     "value-1"
   )
   expect_identical(
-    quickr:::quickr_cached_r_cmd_config_value("FC", cache = cache),
+    quickr_cached_r_cmd_config_value("FC", cache = cache),
     "value-1"
   )
 
   withr::local_envvar(FC = "flang")
   expect_identical(
-    quickr:::quickr_cached_r_cmd_config_value("FC", cache = cache),
+    quickr_cached_r_cmd_config_value("FC", cache = cache),
     "value-2"
   )
   expect_identical(
-    quickr:::quickr_cached_r_cmd_config_value("FC", cache = cache),
+    quickr_cached_r_cmd_config_value("FC", cache = cache),
     "value-2"
   )
   expect_equal(calls, 2L)
@@ -99,17 +99,17 @@ test_that("quickr_cached_r_cmd_config_value keys on explicit Makevars content", 
   withr::local_envvar(R_MAKEVARS_USER = makevars)
 
   expect_identical(
-    quickr:::quickr_cached_r_cmd_config_value("FC", cache = cache),
+    quickr_cached_r_cmd_config_value("FC", cache = cache),
     "value-1"
   )
   expect_identical(
-    quickr:::quickr_cached_r_cmd_config_value("FC", cache = cache),
+    quickr_cached_r_cmd_config_value("FC", cache = cache),
     "value-1"
   )
 
   writeLines("FC=flang", makevars)
   expect_identical(
-    quickr:::quickr_cached_r_cmd_config_value("FC", cache = cache),
+    quickr_cached_r_cmd_config_value("FC", cache = cache),
     "value-2"
   )
   expect_equal(calls, 2L)
@@ -138,13 +138,13 @@ test_that("quickr_cached_r_cmd_config_value keys on default HOME Makevars", {
   ))
 
   expect_identical(
-    quickr:::quickr_cached_r_cmd_config_value("FC", cache = cache),
+    quickr_cached_r_cmd_config_value("FC", cache = cache),
     "value-1"
   )
 
   withr::local_envvar(HOME = home_b)
   expect_identical(
-    quickr:::quickr_cached_r_cmd_config_value("FC", cache = cache),
+    quickr_cached_r_cmd_config_value("FC", cache = cache),
     "value-2"
   )
   expect_equal(calls, 2L)
@@ -171,17 +171,83 @@ test_that("quickr_cached_r_cmd_config_value keys on platform Makevars", {
   ))
 
   expect_identical(
-    quickr:::quickr_cached_r_cmd_config_value("FC", cache = cache),
+    quickr_cached_r_cmd_config_value("FC", cache = cache),
     "value-1"
   )
   expect_identical(
-    quickr:::quickr_cached_r_cmd_config_value("FC", cache = cache),
+    quickr_cached_r_cmd_config_value("FC", cache = cache),
     "value-1"
   )
 
   writeLines("FC=flang", makevars)
   expect_identical(
-    quickr:::quickr_cached_r_cmd_config_value("FC", cache = cache),
+    quickr_cached_r_cmd_config_value("FC", cache = cache),
+    "value-2"
+  )
+  expect_equal(calls, 2L)
+})
+
+test_that("quickr_cached_r_cmd_config_value keys on default site Makevars", {
+  cache <- new.env(parent = emptyenv())
+  r_home <- withr::local_tempdir()
+  site_makevars <- file.path(r_home, "etc", "Makevars.site")
+  dir.create(dirname(site_makevars), recursive = TRUE)
+  writeLines("FC=gfortran", site_makevars)
+  calls <- 0L
+  local_mocked_bindings(
+    R.home = function(...) r_home,
+    .package = "base"
+  )
+  local_mocked_bindings(
+    quickr_r_cmd_config_probe = function(name) {
+      calls <<- calls + 1L
+      list(value = paste0("value-", calls), ok = TRUE)
+    },
+    .package = "quickr"
+  )
+  withr::local_envvar(R_MAKEVARS_SITE = NA)
+
+  expect_identical(
+    quickr_cached_r_cmd_config_value("FC", cache = cache),
+    "value-1"
+  )
+  expect_identical(
+    quickr_cached_r_cmd_config_value("FC", cache = cache),
+    "value-1"
+  )
+
+  writeLines("FC=flang", site_makevars)
+  expect_identical(
+    quickr_cached_r_cmd_config_value("FC", cache = cache),
+    "value-2"
+  )
+  expect_equal(calls, 2L)
+})
+
+test_that("quickr_cached_r_cmd_config_value keys on R_ARCH", {
+  cache <- new.env(parent = emptyenv())
+  calls <- 0L
+  local_mocked_bindings(
+    quickr_r_cmd_config_probe = function(name) {
+      calls <<- calls + 1L
+      list(value = paste0("value-", calls), ok = TRUE)
+    },
+    .package = "quickr"
+  )
+
+  withr::local_envvar(R_ARCH = "/x64")
+  expect_identical(
+    quickr_cached_r_cmd_config_value("FC", cache = cache),
+    "value-1"
+  )
+  expect_identical(
+    quickr_cached_r_cmd_config_value("FC", cache = cache),
+    "value-1"
+  )
+
+  withr::local_envvar(R_ARCH = "/i386")
+  expect_identical(
+    quickr_cached_r_cmd_config_value("FC", cache = cache),
     "value-2"
   )
   expect_equal(calls, 2L)
@@ -199,11 +265,11 @@ test_that("quickr_cached_flang_available reuses successful probes", {
     .package = "quickr"
   )
 
-  result <- quickr:::quickr_cached_flang_available(cache = cache)
+  result <- quickr_cached_flang_available(cache = cache)
   expect_identical(result$path, "/tmp/flang-new")
   expect_true(result$available)
 
-  result <- quickr:::quickr_cached_flang_available(cache = cache)
+  result <- quickr_cached_flang_available(cache = cache)
   expect_identical(result$path, "/tmp/flang-new")
   expect_true(result$available)
   expect_equal(calls, 1L)
@@ -221,11 +287,11 @@ test_that("quickr_cached_flang_available retries failed probes", {
     .package = "quickr"
   )
 
-  result <- quickr:::quickr_cached_flang_available(cache = cache)
+  result <- quickr_cached_flang_available(cache = cache)
   expect_identical(result$path, "/tmp/flang-new")
   expect_false(result$available)
 
-  result <- quickr:::quickr_cached_flang_available(cache = cache)
+  result <- quickr_cached_flang_available(cache = cache)
   expect_identical(result$path, "/tmp/flang-new")
   expect_true(result$available)
   expect_equal(calls, 2L)
@@ -244,14 +310,14 @@ test_that("quickr_cached_flang_available keys on flang path", {
     .package = "quickr"
   )
 
-  result <- quickr:::quickr_cached_flang_available(cache = cache)
+  result <- quickr_cached_flang_available(cache = cache)
   expect_identical(result$path, "/tmp/flang-new")
 
   flang <- "/tmp/flang"
-  result <- quickr:::quickr_cached_flang_available(cache = cache)
+  result <- quickr_cached_flang_available(cache = cache)
   expect_identical(result$path, "/tmp/flang")
 
-  result <- quickr:::quickr_cached_flang_available(cache = cache)
+  result <- quickr_cached_flang_available(cache = cache)
   expect_identical(result$path, "/tmp/flang")
   expect_equal(calls, 2L)
 })
@@ -267,7 +333,7 @@ test_that("quickr_r_cmd_config_probe reports command failures", {
   }
 
   expect_identical(
-    quickr:::quickr_r_cmd_config_probe(
+    quickr_r_cmd_config_probe(
       "FC",
       r_cmd = "R",
       system2 = system2_stub
@@ -275,7 +341,7 @@ test_that("quickr_r_cmd_config_probe reports command failures", {
     list(value = "", ok = FALSE)
   )
   expect_identical(
-    quickr:::quickr_r_cmd_config_probe(
+    quickr_r_cmd_config_probe(
       "FC",
       r_cmd = "R",
       system2 = system2_stub

--- a/tests/testthat/test-compiler-cache.R
+++ b/tests/testthat/test-compiler-cache.R
@@ -800,6 +800,78 @@ test_that("quickr_cached_r_cmd_config_value parses prefixed Makevars assignments
   expect_equal(calls, 2L)
 })
 
+test_that("quickr_cached_r_cmd_config_value keys on ifdef Makevars variables", {
+  cache <- new.env(parent = emptyenv())
+  makevars <- withr::local_tempfile()
+  writeLines(
+    c(
+      "ifdef USE_A",
+      "FC=gfortran",
+      "else",
+      "FC=flang",
+      "endif"
+    ),
+    makevars
+  )
+  calls <- 0L
+  local_mocked_bindings(
+    quickr_r_cmd_config_probe = function(name) {
+      calls <<- calls + 1L
+      list(value = paste0("value-", calls), ok = TRUE)
+    },
+    .package = "quickr"
+  )
+  withr::local_envvar(c(
+    R_MAKEVARS_USER = makevars,
+    USE_A = "1"
+  ))
+
+  expect_identical(
+    quickr_cached_r_cmd_config_value("FC", cache = cache),
+    "value-1"
+  )
+
+  withr::local_envvar(USE_A = NA)
+  expect_identical(
+    quickr_cached_r_cmd_config_value("FC", cache = cache),
+    "value-2"
+  )
+  expect_equal(calls, 2L)
+})
+
+test_that("quickr_cached_r_cmd_config_value retries Makevars with wildcard assignments", {
+  cache <- new.env(parent = emptyenv())
+  root <- withr::local_tempdir()
+  makevars <- file.path(root, "Makevars")
+  compiler_dir <- file.path(root, "compiler")
+  dir.create(compiler_dir)
+  writeLines(
+    paste0("FC = $(wildcard ", file.path(compiler_dir, "gfortran"), ")"),
+    makevars
+  )
+  calls <- 0L
+  local_mocked_bindings(
+    quickr_r_cmd_config_probe = function(name) {
+      calls <<- calls + 1L
+      list(value = paste0("value-", calls), ok = TRUE)
+    },
+    .package = "quickr"
+  )
+  withr::local_envvar(R_MAKEVARS_USER = makevars)
+
+  expect_identical(
+    quickr_cached_r_cmd_config_value("FC", cache = cache),
+    "value-1"
+  )
+
+  file.create(file.path(compiler_dir, "gfortran"))
+  expect_identical(
+    quickr_cached_r_cmd_config_value("FC", cache = cache),
+    "value-2"
+  )
+  expect_equal(calls, 2L)
+})
+
 test_that("quickr_cached_r_cmd_config_value keys on default HOME Makevars", {
   cache <- new.env(parent = emptyenv())
   home_a <- withr::local_tempdir()

--- a/tests/testthat/test-compiler-cache.R
+++ b/tests/testthat/test-compiler-cache.R
@@ -414,6 +414,104 @@ test_that("quickr_cached_r_cmd_config_value propagates variables through include
   expect_equal(calls, 2L)
 })
 
+test_that("quickr_cached_r_cmd_config_value resolves relative includes from cwd", {
+  cache <- new.env(parent = emptyenv())
+  root <- withr::local_tempdir()
+  makevars_dir <- file.path(root, "makevars")
+  build_dir <- file.path(root, "build")
+  real_root <- file.path(root, "real")
+  makevars_root <- file.path(root, "makevars-root")
+  dir.create(makevars_dir)
+  dir.create(build_dir)
+  dir.create(real_root)
+  dir.create(makevars_root)
+  makevars <- file.path(makevars_dir, "Makevars")
+  build_include <- file.path(build_dir, "local.mk")
+  makevars_include <- file.path(makevars_dir, "local.mk")
+  real_toolchain <- file.path(real_root, "toolchain.mk")
+  makevars_toolchain <- file.path(makevars_root, "toolchain.mk")
+  writeLines(
+    c(
+      "include local.mk",
+      "include $(ROOT)/toolchain.mk"
+    ),
+    makevars
+  )
+  writeLines(paste("ROOT =", real_root), build_include)
+  writeLines(paste("ROOT =", makevars_root), makevars_include)
+  writeLines("FC=gfortran", real_toolchain)
+  writeLines("FC=ignored", makevars_toolchain)
+  calls <- 0L
+  local_mocked_bindings(
+    quickr_r_cmd_config_probe = function(name) {
+      calls <<- calls + 1L
+      list(value = paste0("value-", calls), ok = TRUE)
+    },
+    .package = "quickr"
+  )
+  withr::local_envvar(R_MAKEVARS_USER = makevars)
+
+  withr::with_dir(build_dir, {
+    expect_identical(
+      quickr_cached_r_cmd_config_value("FC", cache = cache),
+      "value-1"
+    )
+  })
+
+  writeLines("FC=flang", real_toolchain)
+  withr::with_dir(build_dir, {
+    expect_identical(
+      quickr_cached_r_cmd_config_value("FC", cache = cache),
+      "value-2"
+    )
+  })
+  expect_equal(calls, 2L)
+})
+
+test_that("quickr_cached_r_cmd_config_value honors immediate Makevars assignments", {
+  cache <- new.env(parent = emptyenv())
+  root <- withr::local_tempdir()
+  first_root <- file.path(root, "first")
+  second_root <- file.path(root, "second")
+  dir.create(first_root)
+  dir.create(second_root)
+  makevars <- file.path(root, "Makevars")
+  first_toolchain <- file.path(first_root, "toolchain.mk")
+  second_toolchain <- file.path(second_root, "toolchain.mk")
+  writeLines(
+    c(
+      paste("ROOT =", first_root),
+      "INC := $(ROOT)",
+      paste("ROOT =", second_root),
+      "include $(INC)/toolchain.mk"
+    ),
+    makevars
+  )
+  writeLines("FC=gfortran", first_toolchain)
+  writeLines("FC=ignored", second_toolchain)
+  calls <- 0L
+  local_mocked_bindings(
+    quickr_r_cmd_config_probe = function(name) {
+      calls <<- calls + 1L
+      list(value = paste0("value-", calls), ok = TRUE)
+    },
+    .package = "quickr"
+  )
+  withr::local_envvar(R_MAKEVARS_USER = makevars)
+
+  expect_identical(
+    quickr_cached_r_cmd_config_value("FC", cache = cache),
+    "value-1"
+  )
+
+  writeLines("FC=flang", first_toolchain)
+  expect_identical(
+    quickr_cached_r_cmd_config_value("FC", cache = cache),
+    "value-2"
+  )
+  expect_equal(calls, 2L)
+})
+
 test_that("quickr_cached_r_cmd_config_value keys on R_PLATFORM Makevars", {
   cache <- new.env(parent = emptyenv())
   home <- withr::local_tempdir()

--- a/tests/testthat/test-compiler-cache.R
+++ b/tests/testthat/test-compiler-cache.R
@@ -634,6 +634,55 @@ test_that("quickr_cached_r_cmd_config_value ignores inactive Makevars candidates
   expect_equal(calls, 2L)
 })
 
+test_that("quickr_cached_r_cmd_config_value respects Makevars conditionals", {
+  cache <- new.env(parent = emptyenv())
+  root <- withr::local_tempdir()
+  active_root <- file.path(root, "active")
+  inactive_root <- file.path(root, "inactive")
+  dir.create(active_root)
+  dir.create(inactive_root)
+  makevars <- file.path(root, "Makevars")
+  active_toolchain <- file.path(active_root, "toolchain.mk")
+  inactive_toolchain <- file.path(inactive_root, "toolchain.mk")
+  writeLines(
+    c(
+      "ifeq ($(USE_A),1)",
+      paste("ROOT =", active_root),
+      "else",
+      paste("ROOT =", inactive_root),
+      "endif",
+      "include $(ROOT)/toolchain.mk"
+    ),
+    makevars
+  )
+  writeLines("FC=gfortran", active_toolchain)
+  writeLines("FC=ignored", inactive_toolchain)
+  calls <- 0L
+  local_mocked_bindings(
+    quickr_r_cmd_config_probe = function(name) {
+      calls <<- calls + 1L
+      list(value = paste0("value-", calls), ok = TRUE)
+    },
+    .package = "quickr"
+  )
+  withr::local_envvar(c(
+    R_MAKEVARS_USER = makevars,
+    USE_A = "1"
+  ))
+
+  expect_identical(
+    quickr_cached_r_cmd_config_value("FC", cache = cache),
+    "value-1"
+  )
+
+  writeLines("FC=flang", active_toolchain)
+  expect_identical(
+    quickr_cached_r_cmd_config_value("FC", cache = cache),
+    "value-2"
+  )
+  expect_equal(calls, 2L)
+})
+
 test_that("quickr_cached_r_cmd_config_value keys on default HOME Makevars", {
   cache <- new.env(parent = emptyenv())
   home_a <- withr::local_tempdir()

--- a/tests/testthat/test-compiler-cache.R
+++ b/tests/testthat/test-compiler-cache.R
@@ -1157,6 +1157,46 @@ test_that("quickr_cached_r_cmd_config_value expands ifdef variable names", {
   expect_equal(calls, 2L)
 })
 
+test_that("quickr_cached_r_cmd_config_value retries direct assignments behind indirect ifdef names", {
+  cache <- new.env(parent = emptyenv())
+  makevars <- withr::local_tempfile()
+  writeLines(
+    c(
+      "FLAG_NAME = USE_A",
+      "ifdef $(FLAG_NAME)",
+      "FC=gfortran",
+      "else",
+      "FC=flang",
+      "endif"
+    ),
+    makevars
+  )
+  calls <- 0L
+  local_mocked_bindings(
+    quickr_r_cmd_config_probe = function(name) {
+      calls <<- calls + 1L
+      list(value = paste0("value-", calls), ok = TRUE)
+    },
+    .package = "quickr"
+  )
+  withr::local_envvar(c(
+    R_MAKEVARS_USER = makevars,
+    USE_A = "1"
+  ))
+
+  expect_identical(
+    quickr_cached_r_cmd_config_value("FC", cache = cache),
+    "value-1"
+  )
+
+  withr::local_envvar(USE_A = NA)
+  expect_identical(
+    quickr_cached_r_cmd_config_value("FC", cache = cache),
+    "value-2"
+  )
+  expect_equal(calls, 2L)
+})
+
 test_that("quickr_cached_r_cmd_config_value retries Makevars with wildcard assignments", {
   cache <- new.env(parent = emptyenv())
   root <- withr::local_tempdir()

--- a/tests/testthat/test-compiler-cache.R
+++ b/tests/testthat/test-compiler-cache.R
@@ -84,6 +84,72 @@ test_that("quickr_cached_r_cmd_config_value keys on toolchain env", {
   expect_equal(calls, 2L)
 })
 
+test_that("quickr_cached_r_cmd_config_value keys on explicit Makevars content", {
+  cache <- new.env(parent = emptyenv())
+  makevars <- withr::local_tempfile()
+  writeLines("FC=gfortran", makevars)
+  calls <- 0L
+  local_mocked_bindings(
+    quickr_r_cmd_config_probe = function(name) {
+      calls <<- calls + 1L
+      list(value = paste0("value-", calls), ok = TRUE)
+    },
+    .package = "quickr"
+  )
+  withr::local_envvar(R_MAKEVARS_USER = makevars)
+
+  expect_identical(
+    quickr:::quickr_cached_r_cmd_config_value("FC", cache = cache),
+    "value-1"
+  )
+  expect_identical(
+    quickr:::quickr_cached_r_cmd_config_value("FC", cache = cache),
+    "value-1"
+  )
+
+  writeLines("FC=flang", makevars)
+  expect_identical(
+    quickr:::quickr_cached_r_cmd_config_value("FC", cache = cache),
+    "value-2"
+  )
+  expect_equal(calls, 2L)
+})
+
+test_that("quickr_cached_r_cmd_config_value keys on default HOME Makevars", {
+  cache <- new.env(parent = emptyenv())
+  home_a <- withr::local_tempdir()
+  home_b <- withr::local_tempdir()
+  dir.create(file.path(home_a, ".R"))
+  dir.create(file.path(home_b, ".R"))
+  writeLines("FC=gfortran", file.path(home_a, ".R", "Makevars"))
+  writeLines("FC=flang", file.path(home_b, ".R", "Makevars"))
+  calls <- 0L
+  local_mocked_bindings(
+    quickr_r_cmd_config_probe = function(name) {
+      calls <<- calls + 1L
+      list(value = paste0("value-", calls), ok = TRUE)
+    },
+    .package = "quickr"
+  )
+  withr::local_envvar(c(
+    HOME = home_a,
+    R_USER = NA,
+    R_MAKEVARS_USER = NA
+  ))
+
+  expect_identical(
+    quickr:::quickr_cached_r_cmd_config_value("FC", cache = cache),
+    "value-1"
+  )
+
+  withr::local_envvar(HOME = home_b)
+  expect_identical(
+    quickr:::quickr_cached_r_cmd_config_value("FC", cache = cache),
+    "value-2"
+  )
+  expect_equal(calls, 2L)
+})
+
 test_that("quickr_cached_flang_available reuses successful probes", {
   cache <- new.env(parent = emptyenv())
   calls <- 0L

--- a/tests/testthat/test-compiler-cache.R
+++ b/tests/testthat/test-compiler-cache.R
@@ -323,6 +323,55 @@ test_that("quickr_cached_r_cmd_config_value applies site variables before user i
   expect_equal(calls, 2L)
 })
 
+test_that("quickr_cached_r_cmd_config_value respects env-defined conditional Makevars variables", {
+  cache <- new.env(parent = emptyenv())
+  root <- withr::local_tempdir()
+  default_root <- file.path(root, "default")
+  env_root <- file.path(root, "env")
+  dir.create(default_root)
+  dir.create(env_root)
+  makevars <- file.path(root, "Makevars")
+  default_nested <- file.path(default_root, "toolchain.mk")
+  env_nested <- file.path(env_root, "toolchain.mk")
+  writeLines(
+    c(
+      paste("ROOT ?=", default_root),
+      "include $(ROOT)/toolchain.mk"
+    ),
+    makevars
+  )
+  writeLines("FC=ignored", default_nested)
+  writeLines("FC=gfortran", env_nested)
+  calls <- 0L
+  local_mocked_bindings(
+    quickr_r_cmd_config_probe = function(name) {
+      calls <<- calls + 1L
+      list(value = paste0("value-", calls), ok = TRUE)
+    },
+    .package = "quickr"
+  )
+  withr::local_envvar(c(
+    ROOT = env_root,
+    R_MAKEVARS_USER = makevars
+  ))
+
+  expect_identical(
+    quickr_cached_r_cmd_config_value("FC", cache = cache),
+    "value-1"
+  )
+  expect_identical(
+    quickr_cached_r_cmd_config_value("FC", cache = cache),
+    "value-1"
+  )
+
+  writeLines("FC=flang", env_nested)
+  expect_identical(
+    quickr_cached_r_cmd_config_value("FC", cache = cache),
+    "value-2"
+  )
+  expect_equal(calls, 2L)
+})
+
 test_that("quickr_cached_r_cmd_config_value propagates variables through includes", {
   cache <- new.env(parent = emptyenv())
   root <- withr::local_tempdir()
@@ -358,6 +407,45 @@ test_that("quickr_cached_r_cmd_config_value propagates variables through include
   )
 
   writeLines("FC=flang", nested)
+  expect_identical(
+    quickr_cached_r_cmd_config_value("FC", cache = cache),
+    "value-2"
+  )
+  expect_equal(calls, 2L)
+})
+
+test_that("quickr_cached_r_cmd_config_value keys on R_PLATFORM Makevars", {
+  cache <- new.env(parent = emptyenv())
+  home <- withr::local_tempdir()
+  platform <- "quickr-test-platform"
+  dir.create(file.path(home, ".R"))
+  makevars <- file.path(home, ".R", paste0("Makevars-", platform))
+  writeLines("FC=gfortran", makevars)
+  calls <- 0L
+  local_mocked_bindings(
+    quickr_r_cmd_config_probe = function(name) {
+      calls <<- calls + 1L
+      list(value = paste0("value-", calls), ok = TRUE)
+    },
+    .package = "quickr"
+  )
+  withr::local_envvar(c(
+    HOME = home,
+    R_USER = NA,
+    R_MAKEVARS_USER = NA,
+    R_PLATFORM = platform
+  ))
+
+  expect_identical(
+    quickr_cached_r_cmd_config_value("FC", cache = cache),
+    "value-1"
+  )
+  expect_identical(
+    quickr_cached_r_cmd_config_value("FC", cache = cache),
+    "value-1"
+  )
+
+  writeLines("FC=flang", makevars)
   expect_identical(
     quickr_cached_r_cmd_config_value("FC", cache = cache),
     "value-2"

--- a/tests/testthat/test-compiler-cache.R
+++ b/tests/testthat/test-compiler-cache.R
@@ -1211,6 +1211,42 @@ test_that("quickr_cached_r_cmd_config_value retries Makevars with indirect refs"
   expect_equal(calls, 2L)
 })
 
+test_that("quickr_cached_r_cmd_config_value retries Makevars with computed refs", {
+  cache <- new.env(parent = emptyenv())
+  makevars <- withr::local_tempfile()
+  writeLines(
+    c(
+      "SUFFIX = A",
+      "FC = $(ROOT_$(SUFFIX))"
+    ),
+    makevars
+  )
+  calls <- 0L
+  local_mocked_bindings(
+    quickr_r_cmd_config_probe = function(name) {
+      calls <<- calls + 1L
+      list(value = paste0("value-", calls), ok = TRUE)
+    },
+    .package = "quickr"
+  )
+  withr::local_envvar(c(
+    ROOT_A = "gfortran",
+    R_MAKEVARS_USER = makevars
+  ))
+
+  expect_identical(
+    quickr_cached_r_cmd_config_value("FC", cache = cache),
+    "value-1"
+  )
+
+  withr::local_envvar(ROOT_A = "flang")
+  expect_identical(
+    quickr_cached_r_cmd_config_value("FC", cache = cache),
+    "value-2"
+  )
+  expect_equal(calls, 2L)
+})
+
 test_that("quickr_cached_r_cmd_config_value keys on MAKEFILES content", {
   cache <- new.env(parent = emptyenv())
   makefile <- withr::local_tempfile()

--- a/tests/testthat/test-compiler-cache.R
+++ b/tests/testthat/test-compiler-cache.R
@@ -890,6 +890,46 @@ test_that("quickr_cached_r_cmd_config_value respects Makevars conditionals", {
   expect_equal(calls, 2L)
 })
 
+test_that("quickr_cached_r_cmd_config_value splits ifeq at the first comma", {
+  cache <- new.env(parent = emptyenv())
+  root <- withr::local_tempdir()
+  active_root <- file.path(root, "active")
+  dir.create(active_root)
+  makevars <- file.path(root, "Makevars")
+  toolchain <- file.path(active_root, "toolchain.mk")
+  writeLines(
+    c(
+      "TARGET = x86,arm64",
+      "ifeq ($(TARGET),x86,arm64)",
+      paste("include", toolchain),
+      "endif"
+    ),
+    makevars
+  )
+  writeLines("FC=gfortran", toolchain)
+  calls <- 0L
+  local_mocked_bindings(
+    quickr_r_cmd_config_probe = function(name) {
+      calls <<- calls + 1L
+      list(value = paste0("value-", calls), ok = TRUE)
+    },
+    .package = "quickr"
+  )
+  withr::local_envvar(R_MAKEVARS_USER = makevars)
+
+  expect_identical(
+    quickr_cached_r_cmd_config_value("FC", cache = cache),
+    "value-1"
+  )
+
+  writeLines("FC=flang", toolchain)
+  expect_identical(
+    quickr_cached_r_cmd_config_value("FC", cache = cache),
+    "value-2"
+  )
+  expect_equal(calls, 2L)
+})
+
 test_that("quickr_cached_r_cmd_config_value respects quoted Makevars conditionals", {
   cache <- new.env(parent = emptyenv())
   root <- withr::local_tempdir()
@@ -1673,6 +1713,44 @@ test_that("quickr_cached_r_cmd_config_value ignores Makevars define bodies", {
   )
 
   writeLines("FC=flang", active_toolchain)
+  expect_identical(
+    quickr_cached_r_cmd_config_value("FC", cache = cache),
+    "value-2"
+  )
+  expect_equal(calls, 2L)
+})
+
+test_that("quickr_cached_r_cmd_config_value preserves Makevars define variables", {
+  cache <- new.env(parent = emptyenv())
+  root <- withr::local_tempdir()
+  makevars <- file.path(root, "Makevars")
+  toolchain <- file.path(root, "toolchain.mk")
+  writeLines(
+    c(
+      "define TOOLCHAIN",
+      toolchain,
+      "endef",
+      "include $(TOOLCHAIN)"
+    ),
+    makevars
+  )
+  writeLines("FC=gfortran", toolchain)
+  calls <- 0L
+  local_mocked_bindings(
+    quickr_r_cmd_config_probe = function(name) {
+      calls <<- calls + 1L
+      list(value = paste0("value-", calls), ok = TRUE)
+    },
+    .package = "quickr"
+  )
+  withr::local_envvar(R_MAKEVARS_USER = makevars)
+
+  expect_identical(
+    quickr_cached_r_cmd_config_value("FC", cache = cache),
+    "value-1"
+  )
+
+  writeLines("FC=flang", toolchain)
   expect_identical(
     quickr_cached_r_cmd_config_value("FC", cache = cache),
     "value-2"

--- a/tests/testthat/test-compiler-cache.R
+++ b/tests/testthat/test-compiler-cache.R
@@ -1124,6 +1124,88 @@ test_that("quickr_cached_r_cmd_config_value keys on Makeconf includes", {
   expect_equal(calls, 2L)
 })
 
+test_that("quickr_cached_r_cmd_config_value ignores Makevars recipe assignments", {
+  cache <- new.env(parent = emptyenv())
+  root <- withr::local_tempdir()
+  active_root <- file.path(root, "active")
+  ignored_root <- file.path(root, "ignored")
+  dir.create(active_root)
+  dir.create(ignored_root)
+  makevars <- file.path(root, "Makevars")
+  active_toolchain <- file.path(active_root, "toolchain.mk")
+  ignored_toolchain <- file.path(ignored_root, "toolchain.mk")
+  writeLines(
+    c(
+      paste("ROOT =", active_root),
+      "target:",
+      paste0("\tROOT = ", ignored_root),
+      "include $(ROOT)/toolchain.mk"
+    ),
+    makevars
+  )
+  writeLines("FC=gfortran", active_toolchain)
+  writeLines("FC=ignored", ignored_toolchain)
+  calls <- 0L
+  local_mocked_bindings(
+    quickr_r_cmd_config_probe = function(name) {
+      calls <<- calls + 1L
+      list(value = paste0("value-", calls), ok = TRUE)
+    },
+    .package = "quickr"
+  )
+  withr::local_envvar(R_MAKEVARS_USER = makevars)
+
+  expect_identical(
+    quickr_cached_r_cmd_config_value("FC", cache = cache),
+    "value-1"
+  )
+
+  writeLines("FC=flang", active_toolchain)
+  expect_identical(
+    quickr_cached_r_cmd_config_value("FC", cache = cache),
+    "value-2"
+  )
+  expect_equal(calls, 2L)
+})
+
+test_that("quickr_cached_r_cmd_config_value preserves command-line VAR", {
+  cache <- new.env(parent = emptyenv())
+  root <- withr::local_tempdir()
+  makevars <- file.path(root, "Makevars")
+  toolchain <- file.path(root, "fc.mk")
+  writeLines(
+    c(
+      "VAR = FLIBS",
+      "ifeq ($(VAR),FC)",
+      paste("include", toolchain),
+      "endif"
+    ),
+    makevars
+  )
+  writeLines("FC=gfortran", toolchain)
+  calls <- 0L
+  local_mocked_bindings(
+    quickr_r_cmd_config_probe = function(name) {
+      calls <<- calls + 1L
+      list(value = paste0("value-", calls), ok = TRUE)
+    },
+    .package = "quickr"
+  )
+  withr::local_envvar(R_MAKEVARS_USER = makevars)
+
+  expect_identical(
+    quickr_cached_r_cmd_config_value("FC", cache = cache),
+    "value-1"
+  )
+
+  writeLines("FC=flang", toolchain)
+  expect_identical(
+    quickr_cached_r_cmd_config_value("FC", cache = cache),
+    "value-2"
+  )
+  expect_equal(calls, 2L)
+})
+
 test_that("quickr_cached_r_cmd_config_value seeds Makevars scan with MAKEFILES", {
   cache <- new.env(parent = emptyenv())
   root <- withr::local_tempdir()

--- a/tests/testthat/test-compiler-cache.R
+++ b/tests/testthat/test-compiler-cache.R
@@ -1226,6 +1226,51 @@ test_that("quickr_cached_r_cmd_config_value ignores Makevars recipe assignments"
   expect_equal(calls, 2L)
 })
 
+test_that("quickr_cached_r_cmd_config_value ignores Makevars define bodies", {
+  cache <- new.env(parent = emptyenv())
+  root <- withr::local_tempdir()
+  active_root <- file.path(root, "active")
+  ignored_root <- file.path(root, "ignored")
+  dir.create(active_root)
+  dir.create(ignored_root)
+  makevars <- file.path(root, "Makevars")
+  active_toolchain <- file.path(active_root, "toolchain.mk")
+  ignored_toolchain <- file.path(ignored_root, "toolchain.mk")
+  writeLines(
+    c(
+      paste("ROOT =", active_root),
+      "define toolchain_template",
+      paste("ROOT =", ignored_root),
+      "endef",
+      "include $(ROOT)/toolchain.mk"
+    ),
+    makevars
+  )
+  writeLines("FC=gfortran", active_toolchain)
+  writeLines("FC=ignored", ignored_toolchain)
+  calls <- 0L
+  local_mocked_bindings(
+    quickr_r_cmd_config_probe = function(name) {
+      calls <<- calls + 1L
+      list(value = paste0("value-", calls), ok = TRUE)
+    },
+    .package = "quickr"
+  )
+  withr::local_envvar(R_MAKEVARS_USER = makevars)
+
+  expect_identical(
+    quickr_cached_r_cmd_config_value("FC", cache = cache),
+    "value-1"
+  )
+
+  writeLines("FC=flang", active_toolchain)
+  expect_identical(
+    quickr_cached_r_cmd_config_value("FC", cache = cache),
+    "value-2"
+  )
+  expect_equal(calls, 2L)
+})
+
 test_that("quickr_cached_r_cmd_config_value preserves command-line VAR", {
   cache <- new.env(parent = emptyenv())
   root <- withr::local_tempdir()

--- a/tests/testthat/test-compiler-cache.R
+++ b/tests/testthat/test-compiler-cache.R
@@ -458,6 +458,36 @@ test_that("quickr_cached_r_cmd_config_value distinguishes unset and empty env re
   expect_equal(calls, 2L)
 })
 
+test_that("quickr_cached_r_cmd_config_value keys on single-character Makevars refs", {
+  cache <- new.env(parent = emptyenv())
+  makevars <- withr::local_tempfile()
+  writeLines("FC = $F", makevars)
+  calls <- 0L
+  local_mocked_bindings(
+    quickr_r_cmd_config_probe = function(name) {
+      calls <<- calls + 1L
+      list(value = paste0("value-", calls), ok = TRUE)
+    },
+    .package = "quickr"
+  )
+  withr::local_envvar(c(
+    F = "gfortran",
+    R_MAKEVARS_USER = makevars
+  ))
+
+  expect_identical(
+    quickr_cached_r_cmd_config_value("FC", cache = cache),
+    "value-1"
+  )
+
+  withr::local_envvar(F = "flang")
+  expect_identical(
+    quickr_cached_r_cmd_config_value("FC", cache = cache),
+    "value-2"
+  )
+  expect_equal(calls, 2L)
+})
+
 test_that("quickr_cached_r_cmd_config_value preserves env values for append assignments", {
   cache <- new.env(parent = emptyenv())
   root <- withr::local_tempdir()

--- a/tests/testthat/test-compiler-cache.R
+++ b/tests/testthat/test-compiler-cache.R
@@ -1124,6 +1124,64 @@ test_that("quickr_cached_r_cmd_config_value keys on Makeconf includes", {
   expect_equal(calls, 2L)
 })
 
+test_that("quickr_cached_r_cmd_config_value keys on Makeconf env refs", {
+  cache <- new.env(parent = emptyenv())
+  makeconf <- withr::local_tempfile()
+  writeLines("FC=$(QUICKR_FC)", makeconf)
+  calls <- 0L
+  local_mocked_bindings(
+    quickr_makeconf_path = function() makeconf,
+    quickr_r_cmd_config_probe = function(name) {
+      calls <<- calls + 1L
+      list(value = paste0("value-", calls), ok = TRUE)
+    },
+    .package = "quickr"
+  )
+  withr::local_envvar(QUICKR_FC = "gfortran")
+
+  expect_identical(
+    quickr_cached_r_cmd_config_value("FC", cache = cache),
+    "value-1"
+  )
+
+  withr::local_envvar(QUICKR_FC = "flang")
+  expect_identical(
+    quickr_cached_r_cmd_config_value("FC", cache = cache),
+    "value-2"
+  )
+  expect_equal(calls, 2L)
+})
+
+test_that("quickr_cached_r_cmd_config_value retries dynamic Makeconf inputs", {
+  cache <- new.env(parent = emptyenv())
+  root <- withr::local_tempdir()
+  makeconf <- file.path(root, "Makeconf")
+  compiler_file <- file.path(root, "fc")
+  writeLines("gfortran", compiler_file)
+  writeLines(paste("FC = $(shell cat", compiler_file, ")"), makeconf)
+  calls <- 0L
+  local_mocked_bindings(
+    quickr_makeconf_path = function() makeconf,
+    quickr_r_cmd_config_probe = function(name) {
+      calls <<- calls + 1L
+      list(value = paste0("value-", calls), ok = TRUE)
+    },
+    .package = "quickr"
+  )
+
+  expect_identical(
+    quickr_cached_r_cmd_config_value("FC", cache = cache),
+    "value-1"
+  )
+
+  writeLines("flang", compiler_file)
+  expect_identical(
+    quickr_cached_r_cmd_config_value("FC", cache = cache),
+    "value-2"
+  )
+  expect_equal(calls, 2L)
+})
+
 test_that("quickr_cached_r_cmd_config_value ignores Makevars recipe assignments", {
   cache <- new.env(parent = emptyenv())
   root <- withr::local_tempdir()

--- a/tests/testthat/test-compiler-cache.R
+++ b/tests/testthat/test-compiler-cache.R
@@ -732,6 +732,74 @@ test_that("quickr_cached_r_cmd_config_value respects quoted Makevars conditional
   expect_equal(calls, 2L)
 })
 
+test_that("quickr_cached_r_cmd_config_value retries Makevars with shell functions", {
+  cache <- new.env(parent = emptyenv())
+  root <- withr::local_tempdir()
+  makevars <- file.path(root, "Makevars")
+  compiler_file <- file.path(root, "fc")
+  writeLines("gfortran", compiler_file)
+  writeLines(paste("FC = $(shell cat", compiler_file, ")"), makevars)
+  calls <- 0L
+  local_mocked_bindings(
+    quickr_r_cmd_config_probe = function(name) {
+      calls <<- calls + 1L
+      list(value = paste0("value-", calls), ok = TRUE)
+    },
+    .package = "quickr"
+  )
+  withr::local_envvar(R_MAKEVARS_USER = makevars)
+
+  expect_identical(
+    quickr_cached_r_cmd_config_value("FC", cache = cache),
+    "value-1"
+  )
+
+  writeLines("flang", compiler_file)
+  expect_identical(
+    quickr_cached_r_cmd_config_value("FC", cache = cache),
+    "value-2"
+  )
+  expect_equal(calls, 2L)
+})
+
+test_that("quickr_cached_r_cmd_config_value parses prefixed Makevars assignments", {
+  cache <- new.env(parent = emptyenv())
+  root <- withr::local_tempdir()
+  active_root <- file.path(root, "active")
+  dir.create(active_root)
+  makevars <- file.path(root, "Makevars")
+  active_toolchain <- file.path(active_root, "toolchain.mk")
+  writeLines(
+    c(
+      paste("export ROOT =", active_root),
+      "include $(ROOT)/toolchain.mk"
+    ),
+    makevars
+  )
+  writeLines("FC=gfortran", active_toolchain)
+  calls <- 0L
+  local_mocked_bindings(
+    quickr_r_cmd_config_probe = function(name) {
+      calls <<- calls + 1L
+      list(value = paste0("value-", calls), ok = TRUE)
+    },
+    .package = "quickr"
+  )
+  withr::local_envvar(R_MAKEVARS_USER = makevars)
+
+  expect_identical(
+    quickr_cached_r_cmd_config_value("FC", cache = cache),
+    "value-1"
+  )
+
+  writeLines("FC=flang", active_toolchain)
+  expect_identical(
+    quickr_cached_r_cmd_config_value("FC", cache = cache),
+    "value-2"
+  )
+  expect_equal(calls, 2L)
+})
+
 test_that("quickr_cached_r_cmd_config_value keys on default HOME Makevars", {
   cache <- new.env(parent = emptyenv())
   home_a <- withr::local_tempdir()

--- a/tests/testthat/test-compiler-cache.R
+++ b/tests/testthat/test-compiler-cache.R
@@ -182,6 +182,44 @@ test_that("quickr_cached_r_cmd_config_value keys on Makevars-referenced env", {
   expect_equal(calls, 2L)
 })
 
+test_that("quickr_cached_r_cmd_config_value keys on Makevars CURDIR", {
+  cache <- new.env(parent = emptyenv())
+  makevars <- withr::local_tempfile()
+  build_a <- withr::local_tempdir()
+  build_b <- withr::local_tempdir()
+  writeLines("FC=$(CURDIR)", makevars)
+  calls <- 0L
+  local_mocked_bindings(
+    quickr_r_cmd_config_probe = function(name) {
+      calls <<- calls + 1L
+      list(value = paste0("value-", calls), ok = TRUE)
+    },
+    .package = "quickr"
+  )
+  withr::local_envvar(R_MAKEVARS_USER = makevars)
+
+  withr::with_dir(build_a, {
+    expect_identical(
+      quickr_cached_r_cmd_config_value("FC", cache = cache),
+      "value-1"
+    )
+  })
+  withr::with_dir(build_a, {
+    expect_identical(
+      quickr_cached_r_cmd_config_value("FC", cache = cache),
+      "value-1"
+    )
+  })
+
+  withr::with_dir(build_b, {
+    expect_identical(
+      quickr_cached_r_cmd_config_value("FC", cache = cache),
+      "value-2"
+    )
+  })
+  expect_equal(calls, 2L)
+})
+
 test_that("quickr_cached_r_cmd_config_value keys on included Makevars content", {
   cache <- new.env(parent = emptyenv())
   makevars <- withr::local_tempfile()
@@ -208,6 +246,48 @@ test_that("quickr_cached_r_cmd_config_value keys on included Makevars content", 
   )
 
   writeLines("FC=flang", included)
+  expect_identical(
+    quickr_cached_r_cmd_config_value("FC", cache = cache),
+    "value-2"
+  )
+  expect_equal(calls, 2L)
+})
+
+test_that("quickr_cached_r_cmd_config_value propagates variables through includes", {
+  cache <- new.env(parent = emptyenv())
+  root <- withr::local_tempdir()
+  makevars <- file.path(root, "Makevars")
+  included <- file.path(root, "included.mk")
+  nested <- file.path(root, "nested.mk")
+  writeLines(
+    c(
+      paste("DIR =", root),
+      "include $(DIR)/included.mk"
+    ),
+    makevars
+  )
+  writeLines("include $(DIR)/nested.mk", included)
+  writeLines("FC=gfortran", nested)
+  calls <- 0L
+  local_mocked_bindings(
+    quickr_r_cmd_config_probe = function(name) {
+      calls <<- calls + 1L
+      list(value = paste0("value-", calls), ok = TRUE)
+    },
+    .package = "quickr"
+  )
+  withr::local_envvar(R_MAKEVARS_USER = makevars)
+
+  expect_identical(
+    quickr_cached_r_cmd_config_value("FC", cache = cache),
+    "value-1"
+  )
+  expect_identical(
+    quickr_cached_r_cmd_config_value("FC", cache = cache),
+    "value-1"
+  )
+
+  writeLines("FC=flang", nested)
   expect_identical(
     quickr_cached_r_cmd_config_value("FC", cache = cache),
     "value-2"

--- a/tests/testthat/test-compiler-cache.R
+++ b/tests/testthat/test-compiler-cache.R
@@ -997,6 +997,77 @@ test_that("quickr_cached_r_cmd_config_value seeds Makevars scan with Makeconf", 
   expect_equal(calls, 2L)
 })
 
+test_that("quickr_cached_r_cmd_config_value seeds Makevars scan with MAKEFILES", {
+  cache <- new.env(parent = emptyenv())
+  root <- withr::local_tempdir()
+  makefile <- file.path(root, "global.mk")
+  makevars <- file.path(root, "Makevars")
+  toolchain <- file.path(root, "toolchain.mk")
+  writeLines(paste("ROOT =", root), makefile)
+  writeLines("include $(ROOT)/toolchain.mk", makevars)
+  writeLines("FC=gfortran", toolchain)
+  calls <- 0L
+  local_mocked_bindings(
+    quickr_r_cmd_config_probe = function(name) {
+      calls <<- calls + 1L
+      list(value = paste0("value-", calls), ok = TRUE)
+    },
+    .package = "quickr"
+  )
+  withr::local_envvar(c(
+    MAKEFILES = makefile,
+    R_MAKEVARS_USER = makevars
+  ))
+
+  expect_identical(
+    quickr_cached_r_cmd_config_value("FC", cache = cache),
+    "value-1"
+  )
+
+  writeLines("FC=flang", toolchain)
+  expect_identical(
+    quickr_cached_r_cmd_config_value("FC", cache = cache),
+    "value-2"
+  )
+  expect_equal(calls, 2L)
+})
+
+test_that("quickr_cached_r_cmd_config_value retries Makevars with substitution refs", {
+  cache <- new.env(parent = emptyenv())
+  root <- withr::local_tempdir()
+  makevars <- file.path(root, "Makevars")
+  toolchain <- file.path(root, "toolchain.mk")
+  writeLines(
+    c(
+      paste("ROOT =", root),
+      "include $(ROOT:%=%/toolchain.mk)"
+    ),
+    makevars
+  )
+  writeLines("FC=gfortran", toolchain)
+  calls <- 0L
+  local_mocked_bindings(
+    quickr_r_cmd_config_probe = function(name) {
+      calls <<- calls + 1L
+      list(value = paste0("value-", calls), ok = TRUE)
+    },
+    .package = "quickr"
+  )
+  withr::local_envvar(R_MAKEVARS_USER = makevars)
+
+  expect_identical(
+    quickr_cached_r_cmd_config_value("FC", cache = cache),
+    "value-1"
+  )
+
+  writeLines("FC=flang", toolchain)
+  expect_identical(
+    quickr_cached_r_cmd_config_value("FC", cache = cache),
+    "value-2"
+  )
+  expect_equal(calls, 2L)
+})
+
 test_that("quickr_cached_r_cmd_config_value keys on default HOME Makevars", {
   cache <- new.env(parent = emptyenv())
   home_a <- withr::local_tempdir()

--- a/tests/testthat/test-compiler-cache.R
+++ b/tests/testthat/test-compiler-cache.R
@@ -1,0 +1,183 @@
+skip_on_cran()
+
+test_that("quickr_cached_r_cmd_config_value reuses successful lookups", {
+  cache <- new.env(parent = emptyenv())
+  calls <- 0L
+  local_mocked_bindings(
+    quickr_r_cmd_config_probe = function(name) {
+      calls <<- calls + 1L
+      list(value = paste0(name, "-value-", calls), ok = TRUE)
+    },
+    .package = "quickr"
+  )
+
+  expect_identical(
+    quickr:::quickr_cached_r_cmd_config_value("FC", cache = cache),
+    "FC-value-1"
+  )
+  expect_identical(
+    quickr:::quickr_cached_r_cmd_config_value("FC", cache = cache),
+    "FC-value-1"
+  )
+  expect_equal(calls, 1L)
+})
+
+test_that("quickr_cached_r_cmd_config_value retries failed lookups", {
+  cache <- new.env(parent = emptyenv())
+  calls <- 0L
+  local_mocked_bindings(
+    quickr_r_cmd_config_probe = function(name) {
+      calls <<- calls + 1L
+      if (calls == 1L) {
+        return(list(value = "", ok = FALSE))
+      }
+      list(value = "gfortran", ok = TRUE)
+    },
+    .package = "quickr"
+  )
+
+  expect_identical(
+    quickr:::quickr_cached_r_cmd_config_value("FC", cache = cache),
+    ""
+  )
+  expect_identical(
+    quickr:::quickr_cached_r_cmd_config_value("FC", cache = cache),
+    "gfortran"
+  )
+  expect_identical(
+    quickr:::quickr_cached_r_cmd_config_value("FC", cache = cache),
+    "gfortran"
+  )
+  expect_equal(calls, 2L)
+})
+
+test_that("quickr_cached_r_cmd_config_value keys on toolchain env", {
+  cache <- new.env(parent = emptyenv())
+  calls <- 0L
+  local_mocked_bindings(
+    quickr_r_cmd_config_probe = function(name) {
+      calls <<- calls + 1L
+      list(value = paste0("value-", calls), ok = TRUE)
+    },
+    .package = "quickr"
+  )
+
+  withr::local_envvar(FC = "gfortran")
+  expect_identical(
+    quickr:::quickr_cached_r_cmd_config_value("FC", cache = cache),
+    "value-1"
+  )
+  expect_identical(
+    quickr:::quickr_cached_r_cmd_config_value("FC", cache = cache),
+    "value-1"
+  )
+
+  withr::local_envvar(FC = "flang")
+  expect_identical(
+    quickr:::quickr_cached_r_cmd_config_value("FC", cache = cache),
+    "value-2"
+  )
+  expect_identical(
+    quickr:::quickr_cached_r_cmd_config_value("FC", cache = cache),
+    "value-2"
+  )
+  expect_equal(calls, 2L)
+})
+
+test_that("quickr_cached_flang_available reuses successful probes", {
+  cache <- new.env(parent = emptyenv())
+  calls <- 0L
+  local_mocked_bindings(
+    quickr_flang_path = function() "/tmp/flang-new",
+    quickr_flang_available_at_path = function(flang) {
+      calls <<- calls + 1L
+      list(path = flang, available = TRUE)
+    },
+    .package = "quickr"
+  )
+
+  result <- quickr:::quickr_cached_flang_available(cache = cache)
+  expect_identical(result$path, "/tmp/flang-new")
+  expect_true(result$available)
+
+  result <- quickr:::quickr_cached_flang_available(cache = cache)
+  expect_identical(result$path, "/tmp/flang-new")
+  expect_true(result$available)
+  expect_equal(calls, 1L)
+})
+
+test_that("quickr_cached_flang_available retries failed probes", {
+  cache <- new.env(parent = emptyenv())
+  calls <- 0L
+  local_mocked_bindings(
+    quickr_flang_path = function() "/tmp/flang-new",
+    quickr_flang_available_at_path = function(flang) {
+      calls <<- calls + 1L
+      list(path = flang, available = calls != 1L)
+    },
+    .package = "quickr"
+  )
+
+  result <- quickr:::quickr_cached_flang_available(cache = cache)
+  expect_identical(result$path, "/tmp/flang-new")
+  expect_false(result$available)
+
+  result <- quickr:::quickr_cached_flang_available(cache = cache)
+  expect_identical(result$path, "/tmp/flang-new")
+  expect_true(result$available)
+  expect_equal(calls, 2L)
+})
+
+test_that("quickr_cached_flang_available keys on flang path", {
+  cache <- new.env(parent = emptyenv())
+  calls <- 0L
+  flang <- "/tmp/flang-new"
+  local_mocked_bindings(
+    quickr_flang_path = function() flang,
+    quickr_flang_available_at_path = function(path) {
+      calls <<- calls + 1L
+      list(path = path, available = TRUE)
+    },
+    .package = "quickr"
+  )
+
+  result <- quickr:::quickr_cached_flang_available(cache = cache)
+  expect_identical(result$path, "/tmp/flang-new")
+
+  flang <- "/tmp/flang"
+  result <- quickr:::quickr_cached_flang_available(cache = cache)
+  expect_identical(result$path, "/tmp/flang")
+
+  result <- quickr:::quickr_cached_flang_available(cache = cache)
+  expect_identical(result$path, "/tmp/flang")
+  expect_equal(calls, 2L)
+})
+
+test_that("quickr_r_cmd_config_probe reports command failures", {
+  calls <- 0L
+  system2_stub <- function(command, args, stdout = "", stderr = "", ...) {
+    calls <<- calls + 1L
+    if (calls == 1L) {
+      return(structure(" value ", status = 1L))
+    }
+    "gfortran"
+  }
+
+  expect_identical(
+    quickr:::quickr_r_cmd_config_probe(
+      "FC",
+      r_cmd = "R",
+      system2 = system2_stub
+    ),
+    list(value = "", ok = FALSE)
+  )
+  expect_identical(
+    quickr:::quickr_r_cmd_config_probe(
+      "FC",
+      r_cmd = "R",
+      system2 = system2_stub
+    ),
+    list(value = "gfortran", ok = TRUE)
+  )
+  expect_equal(calls, 2L)
+})

--- a/tests/testthat/test-compiler-cache.R
+++ b/tests/testthat/test-compiler-cache.R
@@ -150,6 +150,42 @@ test_that("quickr_cached_r_cmd_config_value keys on default HOME Makevars", {
   expect_equal(calls, 2L)
 })
 
+test_that("quickr_cached_r_cmd_config_value uses HOME Makevars with R_USER set", {
+  cache <- new.env(parent = emptyenv())
+  home <- withr::local_tempdir()
+  r_user <- withr::local_tempdir()
+  dir.create(file.path(home, ".R"))
+  dir.create(file.path(r_user, ".R"))
+  makevars <- file.path(home, ".R", "Makevars")
+  writeLines("FC=gfortran", makevars)
+  writeLines("FC=ignored", file.path(r_user, ".R", "Makevars"))
+  calls <- 0L
+  local_mocked_bindings(
+    quickr_r_cmd_config_probe = function(name) {
+      calls <<- calls + 1L
+      list(value = paste0("value-", calls), ok = TRUE)
+    },
+    .package = "quickr"
+  )
+  withr::local_envvar(c(
+    HOME = home,
+    R_USER = r_user,
+    R_MAKEVARS_USER = NA
+  ))
+
+  expect_identical(
+    quickr_cached_r_cmd_config_value("FC", cache = cache),
+    "value-1"
+  )
+
+  writeLines("FC=flang", makevars)
+  expect_identical(
+    quickr_cached_r_cmd_config_value("FC", cache = cache),
+    "value-2"
+  )
+  expect_equal(calls, 2L)
+})
+
 test_that("quickr_cached_r_cmd_config_value keys on platform Makevars", {
   cache <- new.env(parent = emptyenv())
   home <- withr::local_tempdir()

--- a/tests/testthat/test-compiler-cache.R
+++ b/tests/testthat/test-compiler-cache.R
@@ -639,6 +639,56 @@ test_that("quickr_cached_r_cmd_config_value honors immediate Makevars assignment
   expect_equal(calls, 2L)
 })
 
+test_that("quickr_cached_r_cmd_config_value expands appends to immediate variables", {
+  cache <- new.env(parent = emptyenv())
+  root <- withr::local_tempdir()
+  first_root <- file.path(root, "first")
+  append_root <- file.path(root, "append")
+  late_root <- file.path(root, "late")
+  dir.create(first_root)
+  dir.create(append_root)
+  dir.create(late_root)
+  makevars <- file.path(root, "Makevars")
+  first_toolchain <- file.path(first_root, "first.mk")
+  append_toolchain <- file.path(append_root, "second.mk")
+  late_toolchain <- file.path(late_root, "second.mk")
+  writeLines(
+    c(
+      paste("ROOT =", first_root),
+      "INCLUDES := $(ROOT)/first.mk",
+      paste("ROOT =", append_root),
+      "INCLUDES += $(ROOT)/second.mk",
+      paste("ROOT =", late_root),
+      "include $(INCLUDES)"
+    ),
+    makevars
+  )
+  writeLines("FC=gfortran", first_toolchain)
+  writeLines("FLIBS=-lappend", append_toolchain)
+  writeLines("FLIBS=-llate", late_toolchain)
+  calls <- 0L
+  local_mocked_bindings(
+    quickr_r_cmd_config_probe = function(name) {
+      calls <<- calls + 1L
+      list(value = paste0("value-", calls), ok = TRUE)
+    },
+    .package = "quickr"
+  )
+  withr::local_envvar(R_MAKEVARS_USER = makevars)
+
+  expect_identical(
+    quickr_cached_r_cmd_config_value("FC", cache = cache),
+    "value-1"
+  )
+
+  writeLines("FLIBS=-lflang", append_toolchain)
+  expect_identical(
+    quickr_cached_r_cmd_config_value("FC", cache = cache),
+    "value-2"
+  )
+  expect_equal(calls, 2L)
+})
+
 test_that("quickr_cached_r_cmd_config_value keys on wildcard Makevars includes", {
   cache <- new.env(parent = emptyenv())
   root <- withr::local_tempdir()

--- a/tests/testthat/test-compiler-cache.R
+++ b/tests/testthat/test-compiler-cache.R
@@ -954,6 +954,49 @@ test_that("quickr_cached_r_cmd_config_value keys on nested MAKEFILES content", {
   expect_equal(calls, 2L)
 })
 
+test_that("quickr_cached_r_cmd_config_value seeds Makevars scan with Makeconf", {
+  cache <- new.env(parent = emptyenv())
+  root <- withr::local_tempdir()
+  makeconf <- file.path(root, "Makeconf")
+  makevars <- file.path(root, "Makevars")
+  toolchain <- file.path(root, "toolchain.mk")
+  writeLines("FC=gfortran", makeconf)
+  writeLines(
+    c(
+      "ifeq ($(FC),gfortran)",
+      paste("include", toolchain),
+      "endif"
+    ),
+    makevars
+  )
+  writeLines("FLIBS=-lgfortran", toolchain)
+  calls <- 0L
+  local_mocked_bindings(
+    quickr_makeconf_path = function() makeconf,
+    quickr_r_cmd_config_probe = function(name) {
+      calls <<- calls + 1L
+      list(value = paste0("value-", calls), ok = TRUE)
+    },
+    .package = "quickr"
+  )
+  withr::local_envvar(c(
+    FC = NA,
+    R_MAKEVARS_USER = makevars
+  ))
+
+  expect_identical(
+    quickr_cached_r_cmd_config_value("FLIBS", cache = cache),
+    "value-1"
+  )
+
+  writeLines("FLIBS=-lflang", toolchain)
+  expect_identical(
+    quickr_cached_r_cmd_config_value("FLIBS", cache = cache),
+    "value-2"
+  )
+  expect_equal(calls, 2L)
+})
+
 test_that("quickr_cached_r_cmd_config_value keys on default HOME Makevars", {
   cache <- new.env(parent = emptyenv())
   home_a <- withr::local_tempdir()

--- a/tests/testthat/test-compiler-cache.R
+++ b/tests/testthat/test-compiler-cache.R
@@ -115,6 +115,73 @@ test_that("quickr_cached_r_cmd_config_value keys on explicit Makevars content", 
   expect_equal(calls, 2L)
 })
 
+test_that("quickr_cached_r_cmd_config_value keys on default Makevars with missing explicit path", {
+  cache <- new.env(parent = emptyenv())
+  home <- withr::local_tempdir()
+  dir.create(file.path(home, ".R"))
+  makevars <- file.path(home, ".R", "Makevars")
+  writeLines("FC=gfortran", makevars)
+  calls <- 0L
+  local_mocked_bindings(
+    quickr_r_cmd_config_probe = function(name) {
+      calls <<- calls + 1L
+      list(value = paste0("value-", calls), ok = TRUE)
+    },
+    .package = "quickr"
+  )
+  withr::local_envvar(c(
+    HOME = home,
+    R_USER = NA,
+    R_MAKEVARS_USER = file.path(home, "missing-Makevars")
+  ))
+
+  expect_identical(
+    quickr_cached_r_cmd_config_value("FC", cache = cache),
+    "value-1"
+  )
+
+  writeLines("FC=flang", makevars)
+  expect_identical(
+    quickr_cached_r_cmd_config_value("FC", cache = cache),
+    "value-2"
+  )
+  expect_equal(calls, 2L)
+})
+
+test_that("quickr_cached_r_cmd_config_value keys on Makevars-referenced env", {
+  cache <- new.env(parent = emptyenv())
+  makevars <- withr::local_tempfile()
+  writeLines("FC=$(QUICKR_TEST_FC)", makevars)
+  calls <- 0L
+  local_mocked_bindings(
+    quickr_r_cmd_config_probe = function(name) {
+      calls <<- calls + 1L
+      list(value = paste0("value-", calls), ok = TRUE)
+    },
+    .package = "quickr"
+  )
+  withr::local_envvar(c(
+    QUICKR_TEST_FC = "gfortran",
+    R_MAKEVARS_USER = makevars
+  ))
+
+  expect_identical(
+    quickr_cached_r_cmd_config_value("FC", cache = cache),
+    "value-1"
+  )
+  expect_identical(
+    quickr_cached_r_cmd_config_value("FC", cache = cache),
+    "value-1"
+  )
+
+  withr::local_envvar(QUICKR_TEST_FC = "flang")
+  expect_identical(
+    quickr_cached_r_cmd_config_value("FC", cache = cache),
+    "value-2"
+  )
+  expect_equal(calls, 2L)
+})
+
 test_that("quickr_cached_r_cmd_config_value keys on included Makevars content", {
   cache <- new.env(parent = emptyenv())
   makevars <- withr::local_tempfile()

--- a/tests/testthat/test-compiler-cache.R
+++ b/tests/testthat/test-compiler-cache.R
@@ -2062,10 +2062,7 @@ test_that("quickr_cached_r_cmd_config_value keys on default site Makevars", {
   writeLines("FC=gfortran", site_makevars)
   calls <- 0L
   local_mocked_bindings(
-    R.home = function(...) r_home,
-    .package = "base"
-  )
-  local_mocked_bindings(
+    quickr_default_site_makevars_path = function() site_makevars,
     quickr_r_cmd_config_probe = function(name) {
       calls <<- calls + 1L
       list(value = paste0("value-", calls), ok = TRUE)

--- a/tests/testthat/test-compiler-cache.R
+++ b/tests/testthat/test-compiler-cache.R
@@ -421,7 +421,7 @@ test_that("quickr_cached_r_cmd_config_value respects env-defined conditional Mak
   expect_equal(calls, 2L)
 })
 
-test_that("quickr_cached_r_cmd_config_value distinguishes unset and empty env refs", {
+test_that("quickr_cached_r_cmd_config_value distinguishes unset and set env refs", {
   cache <- new.env(parent = emptyenv())
   root <- withr::local_tempdir()
   makevars <- file.path(root, "Makevars")
@@ -450,7 +450,7 @@ test_that("quickr_cached_r_cmd_config_value distinguishes unset and empty env re
     "value-1"
   )
 
-  withr::local_envvar(MYFC = "")
+  withr::local_envvar(MYFC = "flang")
   expect_identical(
     quickr_cached_r_cmd_config_value("FC", cache = cache),
     "value-2"
@@ -773,6 +773,7 @@ test_that("quickr_cached_r_cmd_config_value keys on R_PLATFORM Makevars", {
     HOME = home,
     R_USER = NA,
     R_MAKEVARS_USER = NA,
+    R_OSTYPE = "unix",
     R_PLATFORM = platform
   ))
 
@@ -825,7 +826,8 @@ test_that("quickr_cached_r_cmd_config_value ignores inactive Makevars candidates
   )
   withr::local_envvar(c(
     HOME = home,
-    R_MAKEVARS_USER = NA
+    R_MAKEVARS_USER = NA,
+    R_OSTYPE = "unix"
   ))
 
   expect_identical(
@@ -2062,7 +2064,7 @@ test_that("quickr_cached_r_cmd_config_value keys on platform Makevars", {
   cache <- new.env(parent = emptyenv())
   home <- withr::local_tempdir()
   dir.create(file.path(home, ".R"))
-  makevars <- file.path(home, ".R", paste0("Makevars-", R.version$platform))
+  makevars <- file.path(home, ".R", quickr_default_makevars_names()[[1]])
   writeLines("FC=gfortran", makevars)
   calls <- 0L
   local_mocked_bindings(

--- a/tests/testthat/test-compiler-cache.R
+++ b/tests/testthat/test-compiler-cache.R
@@ -115,6 +115,39 @@ test_that("quickr_cached_r_cmd_config_value keys on explicit Makevars content", 
   expect_equal(calls, 2L)
 })
 
+test_that("quickr_cached_r_cmd_config_value keys on included Makevars content", {
+  cache <- new.env(parent = emptyenv())
+  makevars <- withr::local_tempfile()
+  included <- withr::local_tempfile()
+  writeLines(paste("include", included), makevars)
+  writeLines("FC=gfortran", included)
+  calls <- 0L
+  local_mocked_bindings(
+    quickr_r_cmd_config_probe = function(name) {
+      calls <<- calls + 1L
+      list(value = paste0("value-", calls), ok = TRUE)
+    },
+    .package = "quickr"
+  )
+  withr::local_envvar(R_MAKEVARS_USER = makevars)
+
+  expect_identical(
+    quickr_cached_r_cmd_config_value("FC", cache = cache),
+    "value-1"
+  )
+  expect_identical(
+    quickr_cached_r_cmd_config_value("FC", cache = cache),
+    "value-1"
+  )
+
+  writeLines("FC=flang", included)
+  expect_identical(
+    quickr_cached_r_cmd_config_value("FC", cache = cache),
+    "value-2"
+  )
+  expect_equal(calls, 2L)
+})
+
 test_that("quickr_cached_r_cmd_config_value keys on default HOME Makevars", {
   cache <- new.env(parent = emptyenv())
   home_a <- withr::local_tempdir()

--- a/tests/testthat/test-compiler-cache.R
+++ b/tests/testthat/test-compiler-cache.R
@@ -1269,6 +1269,34 @@ test_that("quickr_cached_r_cmd_config_value expands MAKEFILES entries", {
   expect_equal(calls, 2L)
 })
 
+test_that("quickr_cached_r_cmd_config_value retries dynamic MAKEFILES entries", {
+  cache <- new.env(parent = emptyenv())
+  root <- withr::local_tempdir()
+  makefile <- file.path(root, "global.mk")
+  writeLines("FC=gfortran", makefile)
+  calls <- 0L
+  local_mocked_bindings(
+    quickr_r_cmd_config_probe = function(name) {
+      calls <<- calls + 1L
+      list(value = paste0("value-", calls), ok = TRUE)
+    },
+    .package = "quickr"
+  )
+  withr::local_envvar(MAKEFILES = paste0("$(wildcard ", root, "/*.mk)"))
+
+  expect_identical(
+    quickr_cached_r_cmd_config_value("FC", cache = cache),
+    "value-1"
+  )
+
+  writeLines("FC=flang", makefile)
+  expect_identical(
+    quickr_cached_r_cmd_config_value("FC", cache = cache),
+    "value-2"
+  )
+  expect_equal(calls, 2L)
+})
+
 test_that("quickr_cached_r_cmd_config_value keys on nested MAKEFILES content", {
   cache <- new.env(parent = emptyenv())
   root <- withr::local_tempdir()

--- a/tests/testthat/test-compiler.R
+++ b/tests/testthat/test-compiler.R
@@ -131,6 +131,11 @@ test_that("quickr_fortran_compiler_option validates values", {
 })
 
 test_that("quickr_fcompiler_env writes Makevars when flang is usable", {
+  rm(
+    list = ls(envir = quickr_compiler_probe_cache, all.names = TRUE),
+    envir = quickr_compiler_probe_cache
+  )
+
   temp <- withr::local_tempdir()
   prefix <- file.path(temp, "flang")
   dir.create(file.path(prefix, "bin"), recursive = TRUE)
@@ -330,7 +335,7 @@ test_that("quickr_fcompiler_env handles flang unavailable for non-explicit reque
   # Mock flang as preferred but unavailable
   local_mocked_bindings(
     quickr_prefer_flang = function(...) TRUE,
-    quickr_flang_available = function(...) {
+    quickr_cached_flang_available = function(...) {
       list(path = "/tmp/flang", available = FALSE)
     },
     .package = "quickr"
@@ -395,7 +400,7 @@ test_that("quickr_fcompiler_env falls back when flang runtime not found non-expl
   withr::local_options(quickr.fortran_compiler = "auto")
   local_mocked_bindings(
     quickr_prefer_flang = function(...) TRUE,
-    quickr_flang_available = function(...) {
+    quickr_cached_flang_available = function(...) {
       list(path = flang, available = TRUE)
     },
     .package = "quickr"

--- a/tests/testthat/test-quick-windows-paths.R
+++ b/tests/testthat/test-quick-windows-paths.R
@@ -32,7 +32,7 @@ test_that("quickr_windows_add_dll_paths adds missing directories on Windows", {
     RTOOLS_HOME = ""
   ))
 
-  res <- quickr:::quickr_windows_add_dll_paths(
+  res <- quickr_windows_add_dll_paths(
     flags = c(paste0("-L", lib_dir)),
     os_type = "windows",
     config_value = function(...) "",
@@ -65,6 +65,10 @@ test_that("quickr_windows_add_dll_paths adds missing directories on Windows", {
     mustWork = FALSE
   ))
 
+  expect_identical(
+    tolower(normalizePath(res[[1L]], winslash = "\\", mustWork = FALSE)),
+    lib_dir_norm
+  )
   expect_true(lib_dir_norm %in% path_norm)
   expect_true(
     bin_sibling_norm %in% path_norm || bin_dir_norm %in% path_norm
@@ -382,7 +386,7 @@ test_that("quickr_windows_add_dll_paths leaves PATH unchanged when complete", {
     RTOOLS_HOME = ""
   ))
 
-  res <- quickr:::quickr_windows_add_dll_paths(
+  res <- quickr_windows_add_dll_paths(
     flags = c(paste0("-L", lib_dir)),
     os_type = "windows",
     config_value = function(...) "",


### PR DESCRIPTION
## Summary

Cache compiler and toolchain probes used during `quick()` compilation so repeated calls in the same R session do not repeatedly shell out to `R CMD config` or re-run the flang availability probe.

closes #109

## External Changes

- Repeated `quick()` compilation in the same R session is faster after the first compiler-probe pass.
- No public API changes.

## Internal Changes

- Add `quickr_compiler_probe_cache` as the shared session-local cache for compiler probes.
- Add cached `R CMD config` lookup helpers and route `compile()`, `quickr_fcompiler_env()`, `quickr_default_fortran_makevars_lines()`, and `quickr_windows_add_dll_paths()` through them.
- Cache only successful `R CMD config` probes; failed probes are retried.
- Key cached config results by the requested config value plus a toolchain signature covering relevant compiler environment variables, active Makevars files, `MAKEFILES`, Makeconf includes, referenced environment values, and common dynamic Makevars inputs.
- Bypass successful-result caching for Makevars inputs that cannot be represented safely in the signature, such as shell functions, shell assignments, substitution refs, computed refs, and dynamic `MAKEFILES` values.
- Add `quickr_cached_flang_available()`, keyed by the resolved flang path, while retrying unavailable or failed probes.

## Diff Composition

- Runtime/cache code: `R/aaa-utils.R`, `R/compiler.R`, `R/quick.R`
- Tests: `tests/testthat/test-compiler-cache.R`, `tests/testthat/test-compiler.R`, `tests/testthat/test-quick-windows-paths.R`
- Docs/workflows/snapshots: no changes

## Ad-hoc Benchmark

Local macOS benchmark, repeatedly compiling a tiny `quick()` function. Each pair clears the compiler-probe cache before the first compile, then immediately compiles again with the cache warm.

```text
mean cold probe cache: 1.211s
mean warm probe cache: 0.594s
mean speedup: 2.04x

median cold probe cache: 1.191s
median warm probe cache: 0.607s
median pair speedup: 2.00x
```

## Testing

- `air format .`
- `R -q -e 'devtools::test_active_file("tests/testthat/test-compiler-cache.R")'`
- `R -q -e 'devtools::test_active_file("tests/testthat/test-compiler.R")'`
- `R -q -e 'devtools::test_active_file("tests/testthat/test-quick-windows-paths.R")'`
- `python3 /Users/tomasz/.agents/skills/review-loop/scripts/run_review.py --base main`
- `R -q -e 'devtools::test()'` passed: 1,931 assertions
- `R -q -e 'rcmdcheck::rcmdcheck(error_on = "warning")'` passed: 0 errors, 0 warnings, 0 notes
