### PR TITLE
Preload Windows runtime DLL dependencies

### DIFF
--- a/R/quick.R
+++ b/R/quick.R
@@ -296,7 +296,8 @@ compile <- function(fsub, build_dir = tempfile(paste0(fsub@name, "-build-"))) {
     stop("Compilation Error", call. = FALSE)
   }
 
-  quickr_windows_add_dll_paths(link_flags)
+  dll_dirs <- quickr_windows_add_dll_paths(link_flags)
+  quickr_windows_load_dll_dependencies(dll_dirs)
 
   # tryCatch(dyn.unload(dll_path), error = identity)
   dll <- tryCatch(
@@ -436,6 +437,44 @@ quickr_windows_add_dll_paths <- function(
   }
 
   invisible(dirs)
+}
+
+
+quickr_windows_load_dll_dependencies <- function(
+  dirs,
+  os_type = .Platform$OS.type,
+  dyn_load = base::dyn.load
+) {
+  if (!identical(os_type, "windows")) {
+    return(invisible(character()))
+  }
+  stopifnot(is.character(dirs), is.function(dyn_load))
+
+  patterns <- c(
+    "libgcc_s*.dll",
+    "libwinpthread*.dll",
+    "libquadmath*.dll",
+    "libgfortran*.dll",
+    "libopenblas*.dll",
+    "Rblas.dll",
+    "Rlapack.dll"
+  )
+  dlls <- unlist(
+    lapply(patterns, \(pattern) Sys.glob(file.path(dirs, pattern))),
+    use.names = FALSE
+  )
+  dlls <- dlls[file.exists(dlls)]
+  if (!length(dlls)) {
+    return(invisible(character()))
+  }
+
+  dlls <- normalizePath(dlls, winslash = "\\", mustWork = FALSE)
+  dlls <- dlls[!duplicated(tolower(basename(dlls)))]
+  for (dll in dlls) {
+    dyn_load(dll)
+  }
+
+  invisible(dlls)
 }
 
 

--- a/tests/testthat/test-quick-windows-paths.R
+++ b/tests/testthat/test-quick-windows-paths.R
@@ -346,3 +346,39 @@ test_that("quickr_windows_add_dll_paths leaves PATH unchanged when complete", {
   expect_type(res, "character")
   expect_identical(Sys.getenv("PATH"), base_path)
 })
+
+test_that("quickr_windows_load_dll_dependencies preloads known runtime DLLs", {
+  temp <- withr::local_tempdir()
+  lib_dir <- file.path(temp, "lib")
+  bin_dir <- file.path(temp, "bin")
+  dir.create(lib_dir)
+  dir.create(bin_dir)
+  file.create(
+    file.path(lib_dir, "libgfortran-5.dll"),
+    file.path(bin_dir, "libgfortran-5.dll"),
+    file.path(bin_dir, "libquadmath-0.dll"),
+    file.path(lib_dir, "Rlapack.dll")
+  )
+
+  loaded <- character()
+  res <- quickr_windows_load_dll_dependencies(
+    c(lib_dir, bin_dir),
+    os_type = "windows",
+    dyn_load = function(path) {
+      loaded <<- c(loaded, path)
+      structure(list(), class = "DLLInfo")
+    }
+  )
+
+  expected <- normalizePath(
+    c(
+      file.path(bin_dir, "libquadmath-0.dll"),
+      file.path(lib_dir, "libgfortran-5.dll"),
+      file.path(lib_dir, "Rlapack.dll")
+    ),
+    winslash = "\\",
+    mustWork = FALSE
+  )
+  expect_identical(res, expected)
+  expect_identical(loaded, expected)
+})


### PR DESCRIPTION
Draft stacked on #112.

Preloads known Windows runtime DLL dependencies before loading the generated quickr shared library.

Testing:
- `devtools::test_active_file("tests/testthat/test-quick-windows-paths.R")`
- `air format .`
- `rcmdcheck::rcmdcheck(error_on = "warning")`
