### PR TITLE
Simplify flang preference helpers

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -14,3 +14,4 @@
 ^\.claude$
 ^CRAN-SUBMISSION$
 ^doc$
+^\.positai$

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -1,6 +1,7 @@
 # Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
 # Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
 on:
+  workflow_dispatch:
   push:
     branches: [main, master]
   pull_request:

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -1,6 +1,7 @@
 # Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
 # Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
 on:
+  workflow_dispatch:
   push:
     branches: [main, master]
   pull_request:

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ roadmap.md
 /.quarto/
 .tmp
 check/
+.positai

--- a/R/compiler.R
+++ b/R/compiler.R
@@ -1,20 +1,17 @@
-quickr_flang_path <- function(which = Sys.which) {
-  flang_new <- which("flang-new")
+quickr_flang_path <- function() {
+  flang_new <- Sys.which("flang-new")
   if (nzchar(flang_new)) {
     return(flang_new)
   }
-  flang <- which("flang")
+  flang <- Sys.which("flang")
   if (nzchar(flang)) {
     return(flang)
   }
   ""
 }
 
-quickr_flang_available <- function(
-  which = Sys.which,
-  system2 = base::system2
-) {
-  flang <- quickr_flang_path(which = which)
+quickr_flang_available <- function() {
+  flang <- quickr_flang_path()
   if (!nzchar(flang)) {
     return(list(path = "", available = FALSE))
   }
@@ -146,11 +143,7 @@ quickr_fortran_compiler_option <- function(
   )
 }
 
-quickr_prefer_flang <- function(
-  sysname = Sys.info()[["sysname"]],
-  which = Sys.which,
-  system2 = base::system2
-) {
+quickr_prefer_flang <- function() {
   compiler_opt <- quickr_fortran_compiler_option()
   if (identical(compiler_opt, "flang")) {
     return(TRUE)
@@ -163,8 +156,8 @@ quickr_prefer_flang <- function(
   }
 
   # Best-effort: on macOS, prefer flang if it is available.
-  if (sysname == "Darwin") {
-    info <- quickr_flang_available(which = which, system2 = system2)
+  if (Sys.info()[["sysname"]] == "Darwin") {
+    info <- quickr_flang_available()
     return(isTRUE(info$available))
   }
 
@@ -194,8 +187,6 @@ quickr_default_fortran_makevars_lines <- function(
 
 quickr_fcompiler_env <- function(
   build_dir,
-  which = Sys.which,
-  system2 = base::system2,
   write_lines = writeLines,
   sysname = Sys.info()[["sysname"]],
   use_openmp = FALSE,
@@ -211,13 +202,9 @@ quickr_fcompiler_env <- function(
 
   flang <- ""
   flang_runtime <- character()
-  use_flang <- isTRUE(quickr_prefer_flang(
-    sysname = sysname,
-    which = which,
-    system2 = system2
-  ))
+  use_flang <- quickr_prefer_flang()
   if (use_flang) {
-    flang_info <- quickr_flang_available(which = which, system2 = system2)
+    flang_info <- quickr_flang_available()
     flang <- flang_info$path
     if (!isTRUE(flang_info$available)) {
       if (isTRUE(explicit_request)) {

--- a/R/compiler.R
+++ b/R/compiler.R
@@ -143,7 +143,7 @@ quickr_fortran_compiler_option <- function(
   )
 }
 
-quickr_prefer_flang <- function() {
+quickr_prefer_flang <- function(sysname = Sys.info()[["sysname"]]) {
   compiler_opt <- quickr_fortran_compiler_option()
   if (identical(compiler_opt, "flang")) {
     return(TRUE)
@@ -156,7 +156,7 @@ quickr_prefer_flang <- function() {
   }
 
   # Best-effort: on macOS, prefer flang if it is available.
-  if (Sys.info()[["sysname"]] == "Darwin") {
+  if (sysname == "Darwin") {
     info <- quickr_flang_available()
     return(isTRUE(info$available))
   }
@@ -202,7 +202,7 @@ quickr_fcompiler_env <- function(
 
   flang <- ""
   flang_runtime <- character()
-  use_flang <- quickr_prefer_flang()
+  use_flang <- quickr_prefer_flang(sysname = sysname)
   if (use_flang) {
     flang_info <- quickr_flang_available()
     flang <- flang_info$path

--- a/tests/testthat/test-compiler.R
+++ b/tests/testthat/test-compiler.R
@@ -49,8 +49,8 @@ test_that("quickr_r_cmd_config_value returns empty on command failure", {
   )
 })
 
-test_that("quickr_flang_path and quickr_prefer_flang are deterministic with stubs", {
-  which <- function(x) {
+test_that("quickr_flang_path prefers flang-new", {
+  which_stub <- function(x) {
     if (x == "flang-new") {
       "/tmp/flang-new"
     } else if (x == "flang") {
@@ -59,28 +59,28 @@ test_that("quickr_flang_path and quickr_prefer_flang are deterministic with stub
       ""
     }
   }
-  system2_stub <- function(command, args, stdout = TRUE, stderr = TRUE, ...) {
-    "flang version"
-  }
 
-  expect_identical(quickr:::quickr_flang_path(which = which), "/tmp/flang-new")
+  local_mocked_bindings(Sys.which = which_stub, .package = "base")
 
-  withr::local_options(quickr.fortran_compiler = "auto")
+  expect_identical(quickr_flang_path(), "/tmp/flang-new")
+})
 
-  expect_true(quickr:::quickr_prefer_flang(
-    sysname = "Darwin",
-    which = which,
-    system2 = system2_stub
-  ))
-  expect_false(quickr:::quickr_prefer_flang(sysname = "Linux", which = which))
+test_that("flang probe helpers do not expose test-only process hooks", {
+  expect_false("which" %in% names(formals(quickr_flang_path)))
+  expect_false("which" %in% names(formals(quickr_flang_available)))
+  expect_false("system2" %in% names(formals(quickr_flang_available)))
+  expect_false("which" %in% names(formals(quickr_prefer_flang)))
+  expect_false("system2" %in% names(formals(quickr_prefer_flang)))
+  expect_false("which" %in% names(formals(quickr:::quickr_fcompiler_env)))
+  expect_false("system2" %in% names(formals(quickr:::quickr_fcompiler_env)))
 })
 
 test_that("quickr_prefer_flang respects quickr.fortran_compiler", {
   withr::local_options(quickr.fortran_compiler = "flang")
-  expect_true(quickr:::quickr_prefer_flang(sysname = "Linux"))
+  expect_true(quickr_prefer_flang())
 
   withr::local_options(quickr.fortran_compiler = "gfortran")
-  expect_false(quickr:::quickr_prefer_flang(sysname = "Darwin"))
+  expect_false(quickr_prefer_flang())
 })
 
 test_that("quickr_default_fortran_makevars_lines relaxes gfortran cost model", {
@@ -140,8 +140,6 @@ test_that("quickr_fcompiler_env writes Makevars when flang is usable", {
   file.create(flang)
   file.create(file.path(prefix, "lib", "libflang_rt.runtime.dylib"))
 
-  which <- function(x) if (x == "flang-new") flang else ""
-
   cache_env <- environment(quickr:::quickr_flang_runtime_flags)
   old_cache <- cache_env$cache
   cache_env$cache <- NULL
@@ -150,11 +148,15 @@ test_that("quickr_fcompiler_env writes Makevars when flang is usable", {
   build_dir <- file.path(temp, "build")
   dir.create(build_dir)
 
+  local_mocked_bindings(
+    Sys.which = function(x) if (x == "flang-new") flang else "",
+    system2 = function(...) "",
+    .package = "base"
+  )
+
   withr::local_options(quickr.fortran_compiler = "flang")
   env <- quickr:::quickr_fcompiler_env(
     build_dir = build_dir,
-    which = which,
-    system2 = function(...) "",
     sysname = "Darwin"
   )
   expect_true(startsWith(env, "R_MAKEVARS_USER="))
@@ -167,8 +169,6 @@ test_that("quickr_fcompiler_env writes Makevars for default gfortran flags", {
   withr::local_options(quickr.fortran_compiler = "gfortran")
   env <- quickr:::quickr_fcompiler_env(
     build_dir = build_dir,
-    which = function(cmd) "",
-    system2 = function(...) "",
     sysname = "Linux",
     config_value = function(name) {
       if (identical(name, "FC")) "gfortran -m64" else ""
@@ -186,12 +186,12 @@ test_that("quickr_fcompiler_env writes Makevars for default gfortran flags", {
 test_that("quickr_fcompiler_env errors when flang is explicitly requested but unavailable", {
   build_dir <- withr::local_tempdir()
 
+  local_mocked_bindings(Sys.which = function(cmd) "", .package = "base")
+
   withr::local_options(quickr.fortran_compiler = "flang")
   expect_error(
     quickr:::quickr_fcompiler_env(
-      build_dir = build_dir,
-      which = function(cmd) "",
-      system2 = function(...) structure("", status = 1L)
+      build_dir = build_dir
     ),
     "configured to use flang",
     fixed = TRUE
@@ -202,10 +202,12 @@ test_that("quickr_flang_available returns unavailable when system2 fails", {
   which_stub <- function(x) if (x == "flang-new") "/tmp/flang-new" else ""
   system2_fail <- function(...) structure("error", status = 1L)
 
-  result <- quickr:::quickr_flang_available(
-    which = which_stub,
-    system2 = system2_fail
+  local_mocked_bindings(
+    Sys.which = which_stub,
+    system2 = system2_fail,
+    .package = "base"
   )
+  result <- quickr:::quickr_flang_available()
   expect_identical(result$path, "/tmp/flang-new")
   expect_false(result$available)
 })
@@ -317,7 +319,7 @@ test_that("quickr_prefer_flang returns FALSE when flang_auto_disabled", {
     .package = "quickr"
   )
 
-  expect_false(quickr:::quickr_prefer_flang(sysname = "Darwin"))
+  expect_false(quickr_prefer_flang())
 })
 
 test_that("quickr_fcompiler_env handles flang unavailable for non-explicit request", {
@@ -337,8 +339,6 @@ test_that("quickr_fcompiler_env handles flang unavailable for non-explicit reque
   # Should return character() since not explicit and flang unavailable
   result <- quickr:::quickr_fcompiler_env(
     build_dir = build_dir,
-    which = function(x) "",
-    system2 = function(...) "",
     sysname = "Darwin",
     config_value = function(name) if (identical(name, "FC")) "clang" else ""
   )
@@ -361,12 +361,15 @@ test_that("quickr_fcompiler_env errors when flang runtime not found on Darwin ex
   dir.create(build_dir)
 
   withr::local_options(quickr.fortran_compiler = "flang")
+  local_mocked_bindings(
+    Sys.which = function(x) if (x == "flang-new") flang else "",
+    system2 = function(...) "",
+    .package = "base"
+  )
 
   expect_error(
     quickr:::quickr_fcompiler_env(
       build_dir = build_dir,
-      which = function(x) if (x == "flang-new") flang else "",
-      system2 = function(...) "",
       sysname = "Darwin"
     ),
     "could not locate the flang runtime library"
@@ -390,11 +393,16 @@ test_that("quickr_fcompiler_env falls back when flang runtime not found non-expl
   dir.create(build_dir)
 
   withr::local_options(quickr.fortran_compiler = "auto")
+  local_mocked_bindings(
+    quickr_prefer_flang = function(...) TRUE,
+    quickr_flang_available = function(...) {
+      list(path = flang, available = TRUE)
+    },
+    .package = "quickr"
+  )
 
   result <- quickr:::quickr_fcompiler_env(
     build_dir = build_dir,
-    which = function(x) if (x == "flang-new") flang else "",
-    system2 = function(...) "",
     sysname = "Darwin",
     config_value = function(name) if (identical(name, "FC")) "clang" else ""
   )

--- a/tests/testthat/test-flang-preference.R
+++ b/tests/testthat/test-flang-preference.R
@@ -1,12 +1,17 @@
 skip_on_cran()
 
 test_that("quickr_fcompiler_env prefers flang-new when requested", {
-  which <- function(cmd) {
+  which_stub <- function(cmd) {
     if (identical(cmd, "flang-new")) {
       return("/opt/bin/flang-new")
     }
     ""
   }
+  local_mocked_bindings(
+    Sys.which = which_stub,
+    system2 = function(...) "",
+    .package = "base"
+  )
 
   withr::local_options(quickr.fortran_compiler = "flang")
 
@@ -14,8 +19,6 @@ test_that("quickr_fcompiler_env prefers flang-new when requested", {
   dir.create(build_dir)
   env <- quickr:::quickr_fcompiler_env(
     build_dir,
-    system2 = function(...) "",
-    which = which,
     sysname = "Linux"
   )
 
@@ -29,12 +32,17 @@ test_that("quickr_fcompiler_env prefers flang-new when requested", {
 })
 
 test_that("quickr_fcompiler_env falls back to flang when flang-new missing", {
-  which <- function(cmd) {
+  which_stub <- function(cmd) {
     if (identical(cmd, "flang")) {
       return("/opt/bin/flang")
     }
     ""
   }
+  local_mocked_bindings(
+    Sys.which = which_stub,
+    system2 = function(...) "",
+    .package = "base"
+  )
 
   withr::local_options(quickr.fortran_compiler = "flang")
 
@@ -42,8 +50,6 @@ test_that("quickr_fcompiler_env falls back to flang when flang-new missing", {
   dir.create(build_dir)
   env <- quickr:::quickr_fcompiler_env(
     build_dir,
-    system2 = function(...) "",
-    which = which,
     sysname = "Linux"
   )
 
@@ -57,15 +63,17 @@ test_that("quickr_fcompiler_env falls back to flang when flang-new missing", {
 })
 
 test_that("quickr_fcompiler_env returns empty when disabled or unavailable", {
-  which <- function(cmd) ""
   build_dir <- tempfile("quickr-build-")
   dir.create(build_dir)
+  local_mocked_bindings(
+    quickr_prefer_flang = function(...) FALSE,
+    .package = "quickr"
+  )
 
   withr::local_options(quickr.fortran_compiler = "gfortran")
   expect_equal(
     quickr:::quickr_fcompiler_env(
       build_dir,
-      which = which,
       config_value = function(name) if (identical(name, "FC")) "clang" else ""
     ),
     character()
@@ -75,40 +83,14 @@ test_that("quickr_fcompiler_env returns empty when disabled or unavailable", {
   expect_equal(
     quickr:::quickr_fcompiler_env(
       build_dir,
-      which = which,
       config_value = function(name) if (identical(name, "FC")) "clang" else ""
     ),
     character()
   )
-})
-
-test_that("quickr_prefer_flang defaults to TRUE on macOS when flang exists", {
-  which <- function(cmd) {
-    if (identical(cmd, "flang-new")) {
-      return("/opt/bin/flang-new")
-    }
-    ""
-  }
-
-  withr::local_options(quickr.fortran_compiler = "auto")
-
-  expect_true(quickr:::quickr_prefer_flang(
-    sysname = "Darwin",
-    which = which,
-    system2 = function(...) ""
-  ))
-  expect_false(quickr:::quickr_prefer_flang(sysname = "Linux", which = which))
 })
 
 test_that("quickr.fortran_compiler = \"gfortran\" disables auto preference", {
-  which <- function(cmd) {
-    if (identical(cmd, "flang-new")) {
-      return("/opt/bin/flang-new")
-    }
-    ""
-  }
-
   withr::local_options(quickr.fortran_compiler = "gfortran")
 
-  expect_false(quickr:::quickr_prefer_flang(sysname = "Darwin", which = which))
+  expect_false(quickr_prefer_flang())
 })

--- a/tests/testthat/test-flang-preference.R
+++ b/tests/testthat/test-flang-preference.R
@@ -89,6 +89,65 @@ test_that("quickr_fcompiler_env returns empty when disabled or unavailable", {
   )
 })
 
+test_that("quickr_fcompiler_env uses caller-provided sysname for flang auto preference", {
+  temp <- withr::local_tempdir()
+  prefix <- file.path(temp, "flang")
+  dir.create(file.path(prefix, "bin"), recursive = TRUE)
+  dir.create(file.path(prefix, "lib"), recursive = TRUE)
+  flang <- file.path(prefix, "bin", "flang-new")
+  file.create(flang)
+  file.create(file.path(prefix, "lib", "libflang_rt.runtime.dylib"))
+
+  cache_env <- environment(quickr:::quickr_flang_runtime_flags)
+  old_cache <- cache_env$cache
+  cache_env$cache <- NULL
+  on.exit(cache_env$cache <- old_cache, add = TRUE)
+
+  local_mocked_bindings(
+    Sys.which = function(cmd) {
+      if (identical(cmd, "flang-new")) {
+        return(flang)
+      }
+      ""
+    },
+    system2 = function(...) "",
+    .package = "base"
+  )
+
+  withr::local_options(quickr.fortran_compiler = "auto")
+
+  build_dir <- tempfile("quickr-build-")
+  dir.create(build_dir)
+  env <- quickr:::quickr_fcompiler_env(
+    build_dir,
+    sysname = "Darwin"
+  )
+
+  expect_true(startsWith(env, "R_MAKEVARS_USER="))
+  makevars_path <- sub("^R_MAKEVARS_USER=", "", env)
+  expect_true(file.exists(makevars_path))
+  flang_lib <- file.path(
+    dirname(dirname(normalizePath(
+      flang,
+      winslash = "/",
+      mustWork = FALSE
+    ))),
+    "lib"
+  )
+  expect_equal(
+    readLines(makevars_path),
+    c(
+      sprintf("FC=%s", flang),
+      sprintf("F77=%s", flang),
+      paste(
+        "FLIBS +=",
+        sprintf("-L%s", flang_lib),
+        "-lflang_rt.runtime"
+      )
+    )
+  )
+})
+
 test_that("quickr.fortran_compiler = \"gfortran\" disables auto preference", {
   withr::local_options(quickr.fortran_compiler = "gfortran")
 


### PR DESCRIPTION
## Summary

Remove test-only `which` and `system2` parameters from the flang compiler helper signatures, and update the tests to mock process helpers directly.

## External Changes

- No public API changes.

## Internal Changes

- `quickr_flang_path()`, `quickr_flang_available()`, `quickr_prefer_flang()`, and `quickr_fcompiler_env()` now use their real process probes directly instead of carrying test-only hook arguments.
- Compiler tests now use `local_mocked_bindings()` for `Sys.which()` and `system2()`.
- Ignore `.positai` local metadata in source and package builds.

## Testing

- `air format .`
- `R -q -e 'devtools::test_active_file("tests/testthat/test-compiler.R")'`
- `R -q -e 'devtools::test_active_file("tests/testthat/test-flang-preference.R")'`
- `python3 /Users/tomasz/.agents/skills/review-loop/scripts/run_review.py --base main`
