### PR TITLE
Preload Windows runtime DLL dependencies

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -29,6 +29,7 @@ jobs:
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
       R_KEEP_PKG_SOURCE: yes
+      TESTTHAT_CPUS: 5
 
     steps:
       - uses: actions/checkout@v4

--- a/R/quick.R
+++ b/R/quick.R
@@ -426,6 +426,7 @@ quickr_windows_add_dll_paths <- function(
     winslash = "\\",
     mustWork = FALSE
   )
+  path_entries <- path_entries[tolower(path_entries) %in% dirs_norm]
 
   invisible(path_entries)
 }

--- a/R/quick.R
+++ b/R/quick.R
@@ -414,11 +414,20 @@ quickr_windows_add_dll_paths <- function(
   ))
   dirs_norm <- tolower(dirs)
   to_add <- dirs[!dirs_norm %in% existing_norm]
+  path_entries <- existing
   if (length(to_add)) {
-    Sys.setenv(PATH = paste(c(to_add, existing), collapse = ";"))
+    path_entries <- c(to_add, existing)
+    Sys.setenv(PATH = paste(path_entries, collapse = ";"))
   }
+  path_entries <- path_entries[nzchar(path_entries)]
+  path_entries <- path_entries[dir.exists(path_entries)]
+  path_entries <- normalizePath(
+    path_entries,
+    winslash = "\\",
+    mustWork = FALSE
+  )
 
-  invisible(dirs)
+  invisible(path_entries)
 }
 
 

--- a/R/quick.R
+++ b/R/quick.R
@@ -349,9 +349,14 @@ quickr_windows_add_dll_paths <- function(
   dirs <- vapply(dirs, config_path, character(1))
   dirs <- dirs[nzchar(dirs)]
 
+  arch_lib_dirs <- dirs[
+    tolower(basename(dirs)) %in%
+      c("x64", "i386") &
+      tolower(basename(dirname(dirs))) == "lib"
+  ]
   bin_siblings <- c(
     file.path(dirs, "..", "bin"),
-    file.path(dirs, "..", "..", "bin")
+    file.path(arch_lib_dirs, "..", "..", "bin")
   )
 
   config_binpref <- config_path(config_value("BINPREF"))

--- a/R/quick.R
+++ b/R/quick.R
@@ -296,7 +296,8 @@ compile <- function(fsub, build_dir = tempfile(paste0(fsub@name, "-build-"))) {
     stop("Compilation Error", call. = FALSE)
   }
 
-  quickr_windows_add_dll_paths(link_flags)
+  dll_dirs <- quickr_windows_add_dll_paths(link_flags)
+  quickr_windows_load_dll_dependencies(dll_dirs)
 
   # tryCatch(dyn.unload(dll_path), error = identity)
   dll <- tryCatch(
@@ -330,7 +331,7 @@ quickr_windows_add_dll_paths <- function(
   which = Sys.which
 ) {
   if (!identical(os_type, "windows")) {
-    return(invisible(FALSE))
+    return(invisible(character()))
   }
   dirs <- flags[grepl("^-L", flags)]
   dirs <- sub("^-L", "", dirs)
@@ -399,8 +400,9 @@ quickr_windows_add_dll_paths <- function(
   dirs <- dirs[nzchar(dirs)]
   dirs <- dirs[dir.exists(dirs)]
   if (!length(dirs)) {
-    return(invisible(FALSE))
+    return(invisible(character()))
   }
+  dirs <- normalizePath(dirs, winslash = "\\", mustWork = FALSE)
 
   path <- Sys.getenv("PATH", unset = "")
   existing <- strsplit(path, ";", fixed = TRUE)[[1]]
@@ -410,14 +412,51 @@ quickr_windows_add_dll_paths <- function(
     winslash = "\\",
     mustWork = FALSE
   ))
-  dirs_norm <- tolower(normalizePath(dirs, winslash = "\\", mustWork = FALSE))
+  dirs_norm <- tolower(dirs)
   to_add <- dirs[!dirs_norm %in% existing_norm]
   if (length(to_add)) {
     Sys.setenv(PATH = paste(c(to_add, existing), collapse = ";"))
-    return(invisible(TRUE))
   }
 
-  invisible(FALSE)
+  invisible(dirs)
+}
+
+
+quickr_windows_load_dll_dependencies <- function(
+  dirs,
+  os_type = .Platform$OS.type,
+  dyn_load = base::dyn.load
+) {
+  if (!identical(os_type, "windows")) {
+    return(invisible(character()))
+  }
+  stopifnot(is.character(dirs), is.function(dyn_load))
+
+  patterns <- c(
+    "libgcc_s*.dll",
+    "libwinpthread*.dll",
+    "libquadmath*.dll",
+    "libgfortran*.dll",
+    "libopenblas*.dll",
+    "Rblas.dll",
+    "Rlapack.dll"
+  )
+  dlls <- unlist(
+    lapply(patterns, \(pattern) Sys.glob(file.path(dirs, pattern))),
+    use.names = FALSE
+  )
+  dlls <- dlls[file.exists(dlls)]
+  if (!length(dlls)) {
+    return(invisible(character()))
+  }
+
+  dlls <- normalizePath(dlls, winslash = "\\", mustWork = FALSE)
+  dlls <- dlls[!duplicated(tolower(basename(dlls)))]
+  for (dll in dlls) {
+    dyn_load(dll)
+  }
+
+  invisible(dlls)
 }
 
 

--- a/R/quick.R
+++ b/R/quick.R
@@ -333,33 +333,41 @@ quickr_windows_add_dll_paths <- function(
   if (!identical(os_type, "windows")) {
     return(invisible(character()))
   }
+
+  config_path <- function(value) {
+    value <- trimws(value)
+    if (!nzchar(value)) {
+      return("")
+    }
+    value <- sub("^\"([^\"]+)\".*", "\\1", value)
+    value <- sub("^'([^']+)'.*", "\\1", value)
+    strsplit(value, "\\s+")[[1L]][[1L]]
+  }
+
   dirs <- flags[grepl("^-L", flags)]
   dirs <- sub("^-L", "", dirs)
+  dirs <- vapply(dirs, config_path, character(1))
   dirs <- dirs[nzchar(dirs)]
 
-  bin_siblings <- file.path(dirs, "..", "bin")
+  bin_siblings <- c(
+    file.path(dirs, "..", "bin"),
+    file.path(dirs, "..", "..", "bin")
+  )
 
+  config_binpref <- config_path(config_value("BINPREF"))
+  if (nzchar(config_binpref) && !dir.exists(config_binpref)) {
+    config_binpref <- dirname(config_binpref)
+  }
   config_values <- c(
-    config_value("BINPREF"),
     config_value("FC"),
     config_value("F77"),
     config_value("CC"),
     config_value("CXX")
   )
-  config_paths <- vapply(
-    config_values,
-    function(value) {
-      value <- trimws(value)
-      if (!nzchar(value)) {
-        return("")
-      }
-      value <- sub("^\"([^\"]+)\".*", "\\1", value)
-      value <- sub("^'([^']+)'.*", "\\1", value)
-      strsplit(value, "\\s+")[[1L]][[1L]]
-    },
-    character(1)
-  )
-  config_bins <- unique(dirname(config_paths[nzchar(config_paths)]))
+  config_paths <- vapply(config_values, config_path, character(1))
+  config_bins <- dirname(config_paths[nzchar(config_paths)])
+  config_bins <- config_bins[nzchar(config_bins) & config_bins != "."]
+  config_bins <- unique(c(config_binpref, config_bins))
 
   r_bin <- R.home("bin")
   r_bin_x64 <- file.path(r_bin, "x64")
@@ -374,6 +382,16 @@ quickr_windows_add_dll_paths <- function(
     "RTOOLS_HOME"
   ))
   rtools_roots <- rtools_roots[nzchar(rtools_roots)]
+  link_dirs <- gsub("\\", "/", dirs, fixed = TRUE)
+  rtools_link_roots <- sub(
+    "/(?:x86_64|aarch64)-w64-mingw32(?:\\.static(?:\\.posix)?)?/.*$",
+    "",
+    link_dirs
+  )
+  rtools_link_roots <- rtools_link_roots[
+    nzchar(rtools_link_roots) & rtools_link_roots != link_dirs
+  ]
+  rtools_roots <- unique(c(rtools_roots, rtools_link_roots))
   rtools_bins <- unique(c(
     file.path(rtools_roots, "usr", "bin"),
     file.path(rtools_roots, "mingw64", "bin"),

--- a/tests/testthat/test-quick-windows-paths.R
+++ b/tests/testthat/test-quick-windows-paths.R
@@ -3,11 +3,12 @@ skip_on_cran()
 test_that("quickr_windows_add_dll_paths is a no-op off Windows", {
   withr::local_envvar(PATH = "path-entry")
 
-  expect_false(
-    isTRUE(quickr:::quickr_windows_add_dll_paths(
+  expect_length(
+    quickr:::quickr_windows_add_dll_paths(
       flags = character(),
       os_type = "unix"
-    ))
+    ),
+    0
   )
   expect_identical(Sys.getenv("PATH"), "path-entry")
 })
@@ -38,7 +39,7 @@ test_that("quickr_windows_add_dll_paths adds missing directories on Windows", {
     which = function(cmds) setNames(file.path(compiler_dir, cmds), cmds)
   )
 
-  expect_true(isTRUE(res))
+  expect_type(res, "character")
   path <- Sys.getenv("PATH")
   path_entries <- strsplit(path, ";", fixed = TRUE)[[1L]]
   path_entries <- path_entries[nzchar(path_entries)]
@@ -67,6 +68,14 @@ test_that("quickr_windows_add_dll_paths adds missing directories on Windows", {
   expect_true(lib_dir_norm %in% path_norm)
   expect_true(
     bin_sibling_norm %in% path_norm || bin_dir_norm %in% path_norm
+  )
+  expect_true(
+    lib_dir_norm %in%
+      tolower(normalizePath(
+        res,
+        winslash = "\\",
+        mustWork = FALSE
+      ))
   )
   compiler_dir_norm <- tolower(normalizePath(
     compiler_dir,
@@ -106,6 +115,42 @@ test_that("quickr_windows_add_dll_paths leaves PATH unchanged when complete", {
     which = function(cmds) setNames(file.path(compiler_dir, cmds), cmds)
   )
 
-  expect_false(isTRUE(res))
+  expect_type(res, "character")
   expect_identical(Sys.getenv("PATH"), base_path)
+})
+
+test_that("quickr_windows_load_dll_dependencies preloads known runtime DLLs", {
+  temp <- withr::local_tempdir()
+  lib_dir <- file.path(temp, "lib")
+  bin_dir <- file.path(temp, "bin")
+  dir.create(lib_dir)
+  dir.create(bin_dir)
+  file.create(
+    file.path(lib_dir, "libgfortran-5.dll"),
+    file.path(bin_dir, "libgfortran-5.dll"),
+    file.path(bin_dir, "libquadmath-0.dll"),
+    file.path(lib_dir, "Rlapack.dll")
+  )
+
+  loaded <- character()
+  res <- quickr_windows_load_dll_dependencies(
+    c(lib_dir, bin_dir),
+    os_type = "windows",
+    dyn_load = function(path) {
+      loaded <<- c(loaded, path)
+      structure(list(), class = "DLLInfo")
+    }
+  )
+
+  expected <- normalizePath(
+    c(
+      file.path(bin_dir, "libquadmath-0.dll"),
+      file.path(lib_dir, "libgfortran-5.dll"),
+      file.path(lib_dir, "Rlapack.dll")
+    ),
+    winslash = "\\",
+    mustWork = FALSE
+  )
+  expect_identical(res, expected)
+  expect_identical(loaded, expected)
 })

--- a/tests/testthat/test-quick-windows-paths.R
+++ b/tests/testthat/test-quick-windows-paths.R
@@ -172,6 +172,41 @@ test_that("quickr_windows_add_dll_paths returns post-update PATH order", {
   expect_lt(match(config_norm, path_norm), match(lib_norm, path_norm))
 })
 
+test_that("quickr_windows_add_dll_paths excludes unrelated PATH directories", {
+  temp <- withr::local_tempdir()
+  lib_dir <- file.path(temp, "lib")
+  unrelated_dir <- file.path(temp, "unrelated")
+  dir.create(lib_dir)
+  dir.create(unrelated_dir)
+  file.create(file.path(unrelated_dir, "libopenblas-bad.dll"))
+
+  withr::local_envvar(c(
+    PATH = paste(c(unrelated_dir, lib_dir), collapse = ";"),
+    RTOOLS45_HOME = "",
+    RTOOLS44_HOME = "",
+    RTOOLS43_HOME = "",
+    RTOOLS42_HOME = "",
+    RTOOLS40_HOME = "",
+    RTOOLS_HOME = ""
+  ))
+
+  res <- quickr_windows_add_dll_paths(
+    flags = c(paste0("-L", lib_dir)),
+    os_type = "windows",
+    config_value = function(...) "",
+    which = function(cmds) setNames(rep("", length(cmds)), cmds)
+  )
+
+  res_norm <- tolower(normalizePath(res, winslash = "\\", mustWork = FALSE))
+  unrelated_norm <- tolower(normalizePath(
+    unrelated_dir,
+    winslash = "\\",
+    mustWork = FALSE
+  ))
+
+  expect_false(unrelated_norm %in% res_norm)
+})
+
 test_that("quickr_windows_load_dll_dependencies preloads known runtime DLLs", {
   temp <- withr::local_tempdir()
   lib_dir <- file.path(temp, "lib")

--- a/tests/testthat/test-quick-windows-paths.R
+++ b/tests/testthat/test-quick-windows-paths.R
@@ -85,6 +85,238 @@ test_that("quickr_windows_add_dll_paths adds missing directories on Windows", {
   expect_true(compiler_dir_norm %in% path_norm)
 })
 
+test_that("quickr_windows_add_dll_paths adds bin next to arch lib dirs", {
+  temp <- withr::local_tempdir()
+  lib_arch_dir <- file.path(temp, "rtools", "lib", "x64")
+  bin_dir <- file.path(temp, "rtools", "bin")
+  dir.create(lib_arch_dir, recursive = TRUE)
+  dir.create(bin_dir, recursive = TRUE)
+
+  withr::local_envvar(c(
+    PATH = temp,
+    RTOOLS45_HOME = "",
+    RTOOLS44_HOME = "",
+    RTOOLS43_HOME = "",
+    RTOOLS42_HOME = "",
+    RTOOLS40_HOME = "",
+    RTOOLS_HOME = ""
+  ))
+
+  res <- quickr_windows_add_dll_paths(
+    flags = c(paste0("-L", lib_arch_dir)),
+    os_type = "windows",
+    config_value = function(...) "",
+    which = function(cmds) setNames(rep("", length(cmds)), cmds)
+  )
+
+  expect_type(res, "character")
+  path_entries <- strsplit(Sys.getenv("PATH"), ";", fixed = TRUE)[[1L]]
+  path_entries <- path_entries[nzchar(path_entries)]
+  path_norm <- tolower(normalizePath(
+    path_entries,
+    winslash = "\\",
+    mustWork = FALSE
+  ))
+  bin_dir_norm <- tolower(normalizePath(
+    bin_dir,
+    winslash = "\\",
+    mustWork = FALSE
+  ))
+
+  expect_true(bin_dir_norm %in% path_norm)
+})
+
+test_that("quickr_windows_add_dll_paths adds usr/bin from Rtools link dirs", {
+  temp <- withr::local_tempdir()
+  lib_arch_dir <- file.path(
+    temp,
+    "rtools45",
+    "x86_64-w64-mingw32.static.posix",
+    "lib",
+    "x64"
+  )
+  usr_bin <- file.path(temp, "rtools45", "usr", "bin")
+  dir.create(lib_arch_dir, recursive = TRUE)
+  dir.create(usr_bin, recursive = TRUE)
+
+  withr::local_envvar(c(
+    PATH = temp,
+    RTOOLS45_HOME = "",
+    RTOOLS44_HOME = "",
+    RTOOLS43_HOME = "",
+    RTOOLS42_HOME = "",
+    RTOOLS40_HOME = "",
+    RTOOLS_HOME = ""
+  ))
+
+  quickr_windows_add_dll_paths(
+    flags = c(paste0("-L", lib_arch_dir)),
+    os_type = "windows",
+    config_value = function(...) "",
+    which = function(cmds) setNames(rep("", length(cmds)), cmds)
+  )
+
+  path_entries <- strsplit(Sys.getenv("PATH"), ";", fixed = TRUE)[[1L]]
+  path_entries <- path_entries[nzchar(path_entries)]
+  path_norm <- tolower(normalizePath(
+    path_entries,
+    winslash = "\\",
+    mustWork = FALSE
+  ))
+  usr_bin_norm <- tolower(normalizePath(
+    usr_bin,
+    winslash = "\\",
+    mustWork = FALSE
+  ))
+
+  expect_true(usr_bin_norm %in% path_norm)
+})
+
+test_that("quickr_windows_add_dll_paths writes native Windows PATH entries", {
+  temp <- withr::local_tempdir()
+  lib_dir <- file.path(temp, "lib")
+  dir.create(lib_dir)
+
+  withr::local_envvar(c(
+    PATH = temp,
+    RTOOLS45_HOME = "",
+    RTOOLS44_HOME = "",
+    RTOOLS43_HOME = "",
+    RTOOLS42_HOME = "",
+    RTOOLS40_HOME = "",
+    RTOOLS_HOME = ""
+  ))
+
+  quickr_windows_add_dll_paths(
+    flags = c(paste0("-L", lib_dir)),
+    os_type = "windows",
+    config_value = function(...) "",
+    which = function(cmds) setNames(rep("", length(cmds)), cmds)
+  )
+
+  path_entries <- strsplit(Sys.getenv("PATH"), ";", fixed = TRUE)[[1L]]
+  path_entries <- path_entries[nzchar(path_entries)]
+  lib_dir_norm <- tolower(normalizePath(
+    lib_dir,
+    winslash = "\\",
+    mustWork = FALSE
+  ))
+  path_norm <- tolower(normalizePath(
+    path_entries,
+    winslash = "\\",
+    mustWork = FALSE
+  ))
+  lib_entry <- path_entries[path_norm == lib_dir_norm][[1L]]
+
+  expect_true(nzchar(lib_entry))
+  if (identical(.Platform$OS.type, "windows")) {
+    expect_match(lib_entry, "\\\\")
+    expect_false(grepl("/", lib_entry, fixed = TRUE))
+  }
+})
+
+test_that("quickr_windows_add_dll_paths adds BINPREF directories", {
+  temp <- withr::local_tempdir()
+  binpref <- file.path(temp, "rtools", "bin")
+  dir.create(binpref, recursive = TRUE)
+
+  withr::local_envvar(c(
+    PATH = temp,
+    RTOOLS45_HOME = "",
+    RTOOLS44_HOME = "",
+    RTOOLS43_HOME = "",
+    RTOOLS42_HOME = "",
+    RTOOLS40_HOME = "",
+    RTOOLS_HOME = ""
+  ))
+
+  res <- quickr_windows_add_dll_paths(
+    flags = character(),
+    os_type = "windows",
+    config_value = function(name) {
+      if (identical(name, "BINPREF")) {
+        return(paste0(binpref, "/"))
+      }
+      ""
+    },
+    which = function(cmds) setNames(rep("", length(cmds)), cmds)
+  )
+
+  expect_type(res, "character")
+  path_entries <- strsplit(Sys.getenv("PATH"), ";", fixed = TRUE)[[1L]]
+  path_entries <- path_entries[nzchar(path_entries)]
+  path_norm <- tolower(normalizePath(
+    path_entries,
+    winslash = "\\",
+    mustWork = FALSE
+  ))
+  binpref_norm <- tolower(normalizePath(
+    binpref,
+    winslash = "\\",
+    mustWork = FALSE
+  ))
+  expect_true(
+    binpref_norm %in%
+      tolower(normalizePath(
+        res,
+        winslash = "\\",
+        mustWork = FALSE
+      ))
+  )
+  expect_true(binpref_norm %in% path_norm)
+})
+
+test_that("quickr_windows_add_dll_paths adds BINPREF prefix directories", {
+  temp <- withr::local_tempdir()
+  binpref <- file.path(temp, "rtools", "bin")
+  dir.create(binpref, recursive = TRUE)
+
+  withr::local_envvar(c(
+    PATH = temp,
+    RTOOLS45_HOME = "",
+    RTOOLS44_HOME = "",
+    RTOOLS43_HOME = "",
+    RTOOLS42_HOME = "",
+    RTOOLS40_HOME = "",
+    RTOOLS_HOME = ""
+  ))
+
+  res <- quickr_windows_add_dll_paths(
+    flags = character(),
+    os_type = "windows",
+    config_value = function(name) {
+      if (identical(name, "BINPREF")) {
+        return(file.path(binpref, "x86_64-w64-mingw32.static.posix-"))
+      }
+      ""
+    },
+    which = function(cmds) setNames(rep("", length(cmds)), cmds)
+  )
+
+  expect_type(res, "character")
+  path_entries <- strsplit(Sys.getenv("PATH"), ";", fixed = TRUE)[[1L]]
+  path_entries <- path_entries[nzchar(path_entries)]
+  path_norm <- tolower(normalizePath(
+    path_entries,
+    winslash = "\\",
+    mustWork = FALSE
+  ))
+  binpref_norm <- tolower(normalizePath(
+    binpref,
+    winslash = "\\",
+    mustWork = FALSE
+  ))
+  expect_true(
+    binpref_norm %in%
+      tolower(normalizePath(
+        res,
+        winslash = "\\",
+        mustWork = FALSE
+      ))
+  )
+  expect_true(binpref_norm %in% path_norm)
+})
+
 test_that("quickr_windows_add_dll_paths leaves PATH unchanged when complete", {
   temp <- withr::local_tempdir()
   lib_dir <- file.path(temp, "lib")

--- a/tests/testthat/test-quick-windows-paths.R
+++ b/tests/testthat/test-quick-windows-paths.R
@@ -126,6 +126,48 @@ test_that("quickr_windows_add_dll_paths adds bin next to arch lib dirs", {
   expect_true(bin_dir_norm %in% path_norm)
 })
 
+test_that("quickr_windows_add_dll_paths skips unrelated grandparent bin dirs", {
+  temp <- withr::local_tempdir()
+  lib_dir <- file.path(temp, "vendor", "lib")
+  grandparent_bin <- file.path(temp, "bin")
+  dir.create(lib_dir, recursive = TRUE)
+  dir.create(grandparent_bin, recursive = TRUE)
+
+  withr::local_envvar(c(
+    PATH = temp,
+    RTOOLS45_HOME = "",
+    RTOOLS44_HOME = "",
+    RTOOLS43_HOME = "",
+    RTOOLS42_HOME = "",
+    RTOOLS40_HOME = "",
+    RTOOLS_HOME = ""
+  ))
+
+  res <- quickr_windows_add_dll_paths(
+    flags = c(paste0("-L", lib_dir)),
+    os_type = "windows",
+    config_value = function(...) "",
+    which = function(cmds) setNames(rep("", length(cmds)), cmds)
+  )
+
+  grandparent_bin_norm <- tolower(normalizePath(
+    grandparent_bin,
+    winslash = "\\",
+    mustWork = FALSE
+  ))
+  res_norm <- tolower(normalizePath(res, winslash = "\\", mustWork = FALSE))
+  path_entries <- strsplit(Sys.getenv("PATH"), ";", fixed = TRUE)[[1L]]
+  path_entries <- path_entries[nzchar(path_entries)]
+  path_norm <- tolower(normalizePath(
+    path_entries,
+    winslash = "\\",
+    mustWork = FALSE
+  ))
+
+  expect_false(grandparent_bin_norm %in% res_norm)
+  expect_false(grandparent_bin_norm %in% path_norm)
+})
+
 test_that("quickr_windows_add_dll_paths adds usr/bin from Rtools link dirs", {
   temp <- withr::local_tempdir()
   lib_arch_dir <- file.path(

--- a/tests/testthat/test-quick-windows-paths.R
+++ b/tests/testthat/test-quick-windows-paths.R
@@ -119,6 +119,59 @@ test_that("quickr_windows_add_dll_paths leaves PATH unchanged when complete", {
   expect_identical(Sys.getenv("PATH"), base_path)
 })
 
+test_that("quickr_windows_add_dll_paths returns post-update PATH order", {
+  temp <- withr::local_tempdir()
+  lib_dir <- file.path(temp, "lib")
+  config_dir <- file.path(temp, "config")
+  dir.create(lib_dir)
+  dir.create(config_dir)
+
+  base_path <- paste(c(config_dir, lib_dir), collapse = ";")
+  withr::local_envvar(c(
+    PATH = base_path,
+    RTOOLS45_HOME = "",
+    RTOOLS44_HOME = "",
+    RTOOLS43_HOME = "",
+    RTOOLS42_HOME = "",
+    RTOOLS40_HOME = "",
+    RTOOLS_HOME = ""
+  ))
+
+  res <- quickr_windows_add_dll_paths(
+    flags = c(paste0("-L", lib_dir)),
+    os_type = "windows",
+    config_value = function(name) {
+      if (identical(name, "FC")) {
+        return(file.path(config_dir, "gfortran"))
+      }
+      ""
+    },
+    which = function(cmds) setNames(rep("", length(cmds)), cmds)
+  )
+
+  path_entries <- strsplit(Sys.getenv("PATH"), ";", fixed = TRUE)[[1L]]
+  path_entries <- path_entries[nzchar(path_entries)]
+  res_norm <- tolower(normalizePath(res, winslash = "\\", mustWork = FALSE))
+  path_norm <- tolower(normalizePath(
+    path_entries,
+    winslash = "\\",
+    mustWork = FALSE
+  ))
+  config_norm <- tolower(normalizePath(
+    config_dir,
+    winslash = "\\",
+    mustWork = FALSE
+  ))
+  lib_norm <- tolower(normalizePath(
+    lib_dir,
+    winslash = "\\",
+    mustWork = FALSE
+  ))
+
+  expect_lt(match(config_norm, res_norm), match(lib_norm, res_norm))
+  expect_lt(match(config_norm, path_norm), match(lib_norm, path_norm))
+})
+
 test_that("quickr_windows_load_dll_dependencies preloads known runtime DLLs", {
   temp <- withr::local_tempdir()
   lib_dir <- file.path(temp, "lib")


### PR DESCRIPTION
## Summary

This ports the Windows runtime DLL preload work onto `main`. `quick()` now collects Windows runtime directories from link flags, R/Rtools/compiler config, updates `PATH`, and preloads known Fortran/BLAS/LAPACK DLL dependencies before loading generated DLLs.

Public-facing changes:
- Windows `quick()` calls that link BLAS/LAPACK/Fortran runtimes can load generated DLLs with required runtime DLLs available.
- No R API surface changes.

Internal-only changes:
- `quickr_windows_add_dll_paths()` now returns candidate PATH entries instead of a boolean.
- Path discovery handles Rtools arch lib layouts and `BINPREF`, preserves final `PATH` precedence, and avoids unrelated PATH/grandparent bin directories.
- Added Windows path/preload regression coverage.

## Diff Composition

- Runtime code: `R/quick.R` Windows path discovery and dependency preload.
- Tests: expanded `tests/testthat/test-quick-windows-paths.R` coverage.

## Testing

- `R -q -e 'devtools::test_active_file("tests/testthat/test-quick-windows-paths.R")'`
- `air format .`
- `$review-loop` against `origin/main`: clean
- Manual GitHub Actions on `port/windows-runtime-dll-preload`: `R-CMD-check.yaml` pass, `test-coverage.yaml` pass
