### PR TITLE
Cache R CMD config values for the R session

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # quickr (development version)
 
+* Repeated `quick()` compilations now reuse successful `R CMD config` results
+  for the rest of the R session. Restart R after changing the compiler or
+  Makevars configuration.
+
 # quickr 0.3.0
 
 This release adds major new support for linear algebra, local functions,

--- a/R/aaa-utils.R
+++ b/R/aaa-utils.R
@@ -54,11 +54,47 @@ quickr_r_cmd <- function(
   r_cmd
 }
 
+quickr_compiler_probe_cache <- new.env(parent = emptyenv())
+
+quickr_cached_r_cmd_config_value <- function(
+  name,
+  cache = quickr_compiler_probe_cache
+) {
+  stopifnot(is_string(name), is.environment(cache))
+
+  # Compiler configuration is fixed for the R session. Restart R after
+  # changing the toolchain or its configuration files.
+  cache_key <- paste("r_cmd_config", name, sep = "\r")
+  if (exists(cache_key, envir = cache, inherits = FALSE)) {
+    return(get(cache_key, envir = cache, inherits = FALSE))
+  }
+
+  probe <- quickr_r_cmd_config_probe(name)
+  if (isTRUE(probe$ok)) {
+    assign(cache_key, probe$value, envir = cache)
+  }
+  probe$value
+}
+
 quickr_r_cmd_config_value <- function(
   name,
   r_cmd = quickr_r_cmd(),
   system2 = base::system2
 ) {
+  quickr_r_cmd_config_probe(
+    name = name,
+    r_cmd = r_cmd,
+    system2 = system2
+  )$value
+}
+
+quickr_r_cmd_config_probe <- function(
+  name,
+  r_cmd = quickr_r_cmd(),
+  system2 = base::system2
+) {
+  stopifnot(is_string(name), is_string(r_cmd), is.function(system2))
+
   out <- tryCatch(
     suppressWarnings(system2(
       r_cmd,
@@ -66,17 +102,21 @@ quickr_r_cmd_config_value <- function(
       stdout = TRUE,
       stderr = FALSE
     )),
-    error = function(e) character()
+    error = function(e) structure(character(), status = 1L)
   )
   status <- attr(out, "status")
   if (!is.null(status)) {
-    return("")
+    return(list(value = "", ok = FALSE))
   }
   value <- trimws(paste(out, collapse = " "))
-  if (!nzchar(value) || grepl("^ERROR:", value)) {
-    return("")
+  if (!nzchar(value)) {
+    return(list(value = "", ok = TRUE))
   }
-  value
+  if (grepl("^ERROR:", value)) {
+    return(list(value = "", ok = FALSE))
+  }
+
+  list(value = value, ok = TRUE)
 }
 
 

--- a/R/compiler.R
+++ b/R/compiler.R
@@ -165,7 +165,7 @@ quickr_prefer_flang <- function(sysname = Sys.info()[["sysname"]]) {
 }
 
 quickr_default_fortran_makevars_lines <- function(
-  config_value = quickr_r_cmd_config_value
+  config_value = quickr_cached_r_cmd_config_value
 ) {
   fc <- trimws(config_value("FC"))
   if (!nzchar(fc)) {
@@ -191,7 +191,7 @@ quickr_fcompiler_env <- function(
   sysname = Sys.info()[["sysname"]],
   use_openmp = FALSE,
   link_flags = character(),
-  config_value = quickr_r_cmd_config_value
+  config_value = quickr_cached_r_cmd_config_value
 ) {
   stopifnot(is.character(build_dir), length(build_dir) == 1L, nzchar(build_dir))
 

--- a/R/parallel.R
+++ b/R/parallel.R
@@ -173,38 +173,14 @@ openmp_directives <- function(parallel, private = NULL) {
   )
 }
 
-openmp_config_value <- local({
-  cached <- NULL
-
-  function(name, config_value = quickr_r_cmd_config_value) {
-    if (is.null(cached)) {
-      cached <<- list()
-    }
-    cached_value <- cached[[name]]
-    if (!is.null(cached_value)) {
-      return(cached_value)
-    }
-    value <- config_value(name)
-    if (!nzchar(value)) {
-      value <- ""
-    }
-    cached[[name]] <<- value
-    value
-  }
-})
-
 openmp_fflags <- function() {
   env_flags <- trimws(Sys.getenv("QUICKR_OPENMP_FFLAGS", ""))
   if (nzchar(env_flags)) {
     return(env_flags)
   }
 
-  config_flags <- openmp_config_value("SHLIB_OPENMP_FFLAGS")
-  if (nzchar(config_flags)) {
-    return(config_flags)
-  }
-
-  fc <- openmp_config_value("FC")
+  # SHLIB_OPENMP_* are Make macros, not supported R CMD config variables.
+  fc <- quickr_cached_r_cmd_config_value("FC")
   if (grepl("(gfortran|flang)", fc, ignore.case = TRUE)) {
     return("-fopenmp")
   }
@@ -218,17 +194,12 @@ openmp_link_flags <- function(fflags = openmp_fflags()) {
     return(env_flags)
   }
 
-  config_flags <- openmp_config_value("SHLIB_OPENMP_CFLAGS")
-  if (nzchar(config_flags)) {
-    return(config_flags)
-  }
-
-  cc <- openmp_config_value("CC")
+  cc <- quickr_cached_r_cmd_config_value("CC")
   if (nzchar(fflags) && !grepl("clang", cc, ignore.case = TRUE)) {
     return(fflags)
   }
 
-  fc <- openmp_config_value("FC")
+  fc <- quickr_cached_r_cmd_config_value("FC")
   if (grepl("gfortran", fc, ignore.case = TRUE)) {
     compiler <- strsplit(fc, "\\s+")[[1L]][[1L]]
     libname <- if (identical(Sys.info()[["sysname"]], "Darwin")) {

--- a/R/quick.R
+++ b/R/quick.R
@@ -213,7 +213,7 @@ compile <- function(fsub, build_dir = tempfile(paste0(fsub@name, "-build-"))) {
 
   # Link against the same BLAS/LAPACK/Fortran libs as the running R
   # to support generated calls to vendor BLAS (e.g., dgemm, dgesv).
-  cfg <- quickr_r_cmd_config_value
+  cfg <- quickr_cached_r_cmd_config_value
   BLAS_LIBS <- strsplit(cfg("BLAS_LIBS"), "[[:space:]]+")[[1]]
   LAPACK_LIBS <- strsplit(cfg("LAPACK_LIBS"), "[[:space:]]+")[[1]]
   FLIBS <- strsplit(cfg("FLIBS"), "[[:space:]]+")[[1]]
@@ -327,7 +327,7 @@ compile <- function(fsub, build_dir = tempfile(paste0(fsub@name, "-build-"))) {
 quickr_windows_add_dll_paths <- function(
   flags,
   os_type = .Platform$OS.type,
-  config_value = quickr_r_cmd_config_value,
+  config_value = quickr_cached_r_cmd_config_value,
   which = Sys.which
 ) {
   if (!identical(os_type, "windows")) {

--- a/tests/testthat/test-compiler.R
+++ b/tests/testthat/test-compiler.R
@@ -2,6 +2,35 @@
 
 skip_on_cran()
 
+local_empty_compiler_probe_cache <- function(envir = parent.frame()) {
+  cache <- get0(
+    "quickr_compiler_probe_cache",
+    envir = asNamespace("quickr"),
+    inherits = FALSE
+  )
+  if (is.null(cache)) {
+    return(invisible(NULL))
+  }
+
+  old <- as.list.environment(cache, all.names = TRUE)
+  withr::defer(
+    {
+      entries <- ls(envir = cache, all.names = TRUE)
+      if (length(entries)) {
+        rm(list = entries, envir = cache)
+      }
+      list2env(old, envir = cache)
+    },
+    envir = envir
+  )
+
+  entries <- ls(envir = cache, all.names = TRUE)
+  if (length(entries)) {
+    rm(list = entries, envir = cache)
+  }
+  invisible(NULL)
+}
+
 test_that("quickr_r_cmd_config_value captures only stdout", {
   expect_identical(
     deparse(formals(quickr:::quickr_r_cmd_config_value)$system2),
@@ -46,6 +75,28 @@ test_that("quickr_r_cmd_config_value returns empty on command failure", {
       system2 = system2_stub
     ),
     ""
+  )
+})
+
+test_that("R CMD config probe distinguishes empty values from errors", {
+  empty_value <- function(...) character()
+  expect_identical(
+    quickr:::quickr_r_cmd_config_probe(
+      "CC",
+      r_cmd = "R",
+      system2 = empty_value
+    ),
+    list(value = "", ok = TRUE)
+  )
+
+  error_value <- function(...) "ERROR: no information for variable 'CC'"
+  expect_identical(
+    quickr:::quickr_r_cmd_config_probe(
+      "CC",
+      r_cmd = "R",
+      system2 = error_value
+    ),
+    list(value = "", ok = FALSE)
   )
 })
 
@@ -458,4 +509,68 @@ test_that("compile cleans existing build directories and reports failures", {
   )
   expect_true(dir.exists(build_dir))
   expect_false(file.exists(file.path(build_dir, "stale.txt")))
+})
+
+test_that("quick reuses successful R CMD config probes", {
+  local_empty_compiler_probe_cache()
+  withr::local_options(quickr.fortran_compiler = "gfortran")
+
+  probe <- quickr_r_cmd_config_probe
+  events <- list()
+  local_mocked_bindings(
+    quickr_r_cmd_config_probe = function(name, ...) {
+      result <- probe(name, ...)
+      events[[length(events) + 1L]] <<- list(name = name, ok = result$ok)
+      result
+    },
+    .package = "quickr"
+  )
+
+  fn <- function(x) {
+    declare(type(x = double(1)))
+    x + 1
+  }
+
+  expect_quick_identical(fn, 1)
+  first_events <- events
+  expect_quick_identical(fn, 3)
+
+  successful <- unique(vapply(
+    first_events[vapply(first_events, `[[`, logical(1), "ok")],
+    `[[`,
+    character(1),
+    "name"
+  ))
+  later <- events[seq_along(events) > length(first_events)]
+  later_names <- vapply(later, `[[`, character(1), "name")
+  expect_length(intersect(successful, later_names), 0L)
+})
+
+test_that("quick retries failed R CMD config probes", {
+  local_empty_compiler_probe_cache()
+  withr::local_options(quickr.fortran_compiler = "gfortran")
+
+  probe <- quickr_r_cmd_config_probe
+  blas_calls <- 0L
+  local_mocked_bindings(
+    quickr_r_cmd_config_probe = function(name, ...) {
+      if (identical(name, "BLAS_LIBS")) {
+        blas_calls <<- blas_calls + 1L
+        if (blas_calls == 1L) {
+          return(list(value = "", ok = FALSE))
+        }
+      }
+      probe(name, ...)
+    },
+    .package = "quickr"
+  )
+
+  fn <- function(x) {
+    declare(type(x = double(1)))
+    x + 1
+  }
+
+  expect_quick_identical(fn, 1)
+  expect_quick_identical(fn, 3)
+  expect_identical(blas_calls, 2L)
 })

--- a/tests/testthat/test-openmp-utils.R
+++ b/tests/testthat/test-openmp-utils.R
@@ -39,31 +39,6 @@ test_that("openmp_makevars_lines errors when linker flags are missing", {
   )
 })
 
-test_that("openmp_config_value caches toolchain lookups", {
-  cache_env <- environment(quickr:::openmp_config_value)
-  old_cache <- cache_env$cached
-  old_config <- cache_env$quickr_r_cmd_config_value
-  withr::defer(cache_env$cached <- old_cache)
-  withr::defer({
-    if (is.null(old_config)) {
-      rm(quickr_r_cmd_config_value, envir = cache_env)
-    } else {
-      cache_env$quickr_r_cmd_config_value <- old_config
-    }
-  })
-  cache_env$cached <- NULL
-
-  calls <- 0
-  cache_env$quickr_r_cmd_config_value <- function(...) {
-    calls <<- calls + 1
-    "value"
-  }
-
-  expect_equal(quickr:::openmp_config_value("QUICKR_TEST_CACHE"), "value")
-  expect_equal(quickr:::openmp_config_value("QUICKR_TEST_CACHE"), "value")
-  expect_equal(calls, 1)
-})
-
 test_that("get_pending_parallel returns NULL for NULL or non-scope", {
   expect_null(quickr:::get_pending_parallel(NULL))
   expect_null(quickr:::get_pending_parallel(list()))
@@ -117,7 +92,7 @@ test_that("openmp_link_flags uses env variable first", {
 
 test_that("openmp_fflags returns empty when no config found", {
   local_mocked_bindings(
-    openmp_config_value = function(...) "",
+    quickr_cached_r_cmd_config_value = function(...) "",
     .package = "quickr"
   )
   withr::local_envvar(QUICKR_OPENMP_FFLAGS = "")
@@ -128,8 +103,8 @@ test_that("openmp_fflags returns empty when no config found", {
 
 test_that("openmp_link_flags returns fflags for non-clang CC", {
   local_mocked_bindings(
-    openmp_config_value = function(name, ...) {
-      switch(name, SHLIB_OPENMP_CFLAGS = "", CC = "gcc", "")
+    quickr_cached_r_cmd_config_value = function(name, ...) {
+      switch(name, CC = "gcc", "")
     },
     .package = "quickr"
   )
@@ -141,8 +116,8 @@ test_that("openmp_link_flags returns fflags for non-clang CC", {
 
 test_that("openmp_link_flags returns empty for clang CC", {
   local_mocked_bindings(
-    openmp_config_value = function(name, ...) {
-      switch(name, SHLIB_OPENMP_CFLAGS = "", CC = "clang", FC = "flang", "")
+    quickr_cached_r_cmd_config_value = function(name, ...) {
+      switch(name, CC = "clang", FC = "flang", "")
     },
     .package = "quickr"
   )

--- a/tests/testthat/test-parallel-declare.R
+++ b/tests/testthat/test-parallel-declare.R
@@ -27,6 +27,38 @@ test_that("declare(parallel()) and declare(omp()) parallelize loops", {
   expect_quick_identical(parallel_sapply, list(x))
 })
 
+test_that("parallel quick avoids unsupported R CMD config probes", {
+  skip_if_no_openmp()
+  withr::local_options(quickr.fortran_compiler = "gfortran")
+
+  probe <- quickr_r_cmd_config_probe
+  names <- character()
+  local_mocked_bindings(
+    quickr_r_cmd_config_probe = function(name, ...) {
+      names <<- c(names, name)
+      probe(name, ...)
+    },
+    .package = "quickr"
+  )
+
+  fn <- function(x) {
+    declare(
+      type(x = double(NA)),
+      type(out = double(length(x)))
+    )
+    out <- double(length(x))
+    declare(parallel())
+    for (i in seq_along(x)) {
+      out[i] <- x[i] + 1
+    }
+    out
+  }
+
+  expect_quick_identical(fn, list(c(1, 2, 3)))
+  unsupported <- c("SHLIB_OPENMP_FFLAGS", "SHLIB_OPENMP_CFLAGS")
+  expect_length(intersect(names, unsupported), 0L)
+})
+
 test_that("parallel sapply supports axpy patterns", {
   skip_if_no_openmp()
 


### PR DESCRIPTION
## Summary

Cache successful `R CMD config` lookups for the lifetime of the R session so
repeated `quick()` compilations avoid redundant subprocess probes. Failed
probes remain uncached and are retried.

Supersedes #110.
Closes #109.

## External changes

- Repeated `quick()` compilations reuse compiler and linker configuration for
  the rest of the R session.
- Restart R after changing the compiler or Makevars configuration.
- There are no public API changes.

## Internal changes

- Add one session-local cache shared by compilation, compiler setup, OpenMP
  configuration, and Windows DLL path discovery.
- Cache successful empty values while leaving failed probes uncached.
- Stop querying `SHLIB_OPENMP_*` Make macros through `R CMD config`; use
  environment overrides and supported `FC`/`CC` fallbacks.
- Leave flang discovery and runtime probing unchanged.

## Benchmarks

Using gfortran:

| Benchmark | Runs | Before | After | Speedup |
| --- | ---: | ---: | ---: | ---: |
| Quickr-focused anvl tests (quickr 0.3.0 → this branch) | 3 fresh sessions | 75.60 s | 38.02 s | 1.99x |
| Local scalar `x + 1` (cold → warm) | 5 pairs | 1.382 s | 0.536 s | 2.58x |

All 63 anvl test blocks passed with both quickr versions.

## Testing

- `air format .`
- `R -q -e 'devtools::test(filter = "cran-budget|compiler|openmp|quick-windows-paths|parallel-declare")'`
- `R -q -e 'devtools::test(filter = "compiler")'` (57 assertions)
- `R -q -e 'devtools::test()'` (1,731 assertions)
- `R -q -e 'covr::package_coverage()'` (all changed branches covered)
- `R -q -e 'rcmdcheck::rcmdcheck(error_on = "warning")'` (0 errors, 0 warnings, 0 notes)
