### PR TITLE
Simplify compiler helper signatures

### DIFF
--- a/R/aaa-utils.R
+++ b/R/aaa-utils.R
@@ -42,13 +42,9 @@ scope_fortran_symbol <- function(sym, scope) {
   sym
 }
 
-quickr_r_cmd <- function(
-  os_type = .Platform$OS.type,
-  r_home = R.home,
-  file_exists = file.exists
-) {
-  r_cmd <- r_home("bin/R")
-  if (identical(os_type, "windows") && !file_exists(r_cmd)) {
+quickr_r_cmd <- function(os_type = .Platform$OS.type) {
+  r_cmd <- R.home("bin/R")
+  if (identical(os_type, "windows") && !file.exists(r_cmd)) {
     r_cmd <- paste0(r_cmd, ".exe")
   }
   r_cmd
@@ -56,48 +52,39 @@ quickr_r_cmd <- function(
 
 quickr_compiler_probe_cache <- new.env(parent = emptyenv())
 
-quickr_cached_r_cmd_config_value <- function(
-  name,
-  cache = quickr_compiler_probe_cache
-) {
-  stopifnot(is_string(name), is.environment(cache))
+quickr_cached_r_cmd_config_value <- function(name) {
+  stopifnot(is_string(name))
 
   # Compiler configuration is fixed for the R session. Restart R after
   # changing the toolchain or its configuration files.
   cache_key <- paste("r_cmd_config", name, sep = "\r")
-  if (exists(cache_key, envir = cache, inherits = FALSE)) {
-    return(get(cache_key, envir = cache, inherits = FALSE))
+  if (
+    exists(
+      cache_key,
+      envir = quickr_compiler_probe_cache,
+      inherits = FALSE
+    )
+  ) {
+    return(get(
+      cache_key,
+      envir = quickr_compiler_probe_cache,
+      inherits = FALSE
+    ))
   }
 
   probe <- quickr_r_cmd_config_probe(name)
   if (isTRUE(probe$ok)) {
-    assign(cache_key, probe$value, envir = cache)
+    assign(cache_key, probe$value, envir = quickr_compiler_probe_cache)
   }
   probe$value
 }
 
-quickr_r_cmd_config_value <- function(
-  name,
-  r_cmd = quickr_r_cmd(),
-  system2 = base::system2
-) {
-  quickr_r_cmd_config_probe(
-    name = name,
-    r_cmd = r_cmd,
-    system2 = system2
-  )$value
-}
-
-quickr_r_cmd_config_probe <- function(
-  name,
-  r_cmd = quickr_r_cmd(),
-  system2 = base::system2
-) {
-  stopifnot(is_string(name), is_string(r_cmd), is.function(system2))
+quickr_r_cmd_config_probe <- function(name) {
+  stopifnot(is_string(name))
 
   out <- tryCatch(
-    suppressWarnings(system2(
-      r_cmd,
+    suppressWarnings(base::system2(
+      quickr_r_cmd(),
       c("CMD", "config", name),
       stdout = TRUE,
       stderr = FALSE

--- a/R/compiler.R
+++ b/R/compiler.R
@@ -164,10 +164,8 @@ quickr_prefer_flang <- function(sysname = Sys.info()[["sysname"]]) {
   FALSE
 }
 
-quickr_default_fortran_makevars_lines <- function(
-  config_value = quickr_cached_r_cmd_config_value
-) {
-  fc <- trimws(config_value("FC"))
+quickr_default_fortran_makevars_lines <- function() {
+  fc <- trimws(quickr_cached_r_cmd_config_value("FC"))
   if (!nzchar(fc)) {
     return(character())
   }
@@ -187,11 +185,9 @@ quickr_default_fortran_makevars_lines <- function(
 
 quickr_fcompiler_env <- function(
   build_dir,
-  write_lines = writeLines,
   sysname = Sys.info()[["sysname"]],
   use_openmp = FALSE,
-  link_flags = character(),
-  config_value = quickr_cached_r_cmd_config_value
+  link_flags = character()
 ) {
   stopifnot(is.character(build_dir), length(build_dir) == 1L, nzchar(build_dir))
 
@@ -246,7 +242,7 @@ quickr_fcompiler_env <- function(
   default_makevars_lines <- if (use_flang) {
     character()
   } else {
-    quickr_default_fortran_makevars_lines(config_value = config_value)
+    quickr_default_fortran_makevars_lines()
   }
 
   if (!use_flang && !use_openmp && !length(default_makevars_lines)) {
@@ -270,7 +266,7 @@ quickr_fcompiler_env <- function(
       paste("PKG_LIBS +=", paste(link_flags, collapse = " "))
     }
   )
-  write_lines(
+  writeLines(
     makevars_lines,
     makevars_path
   )

--- a/R/quick.R
+++ b/R/quick.R
@@ -326,9 +326,7 @@ compile <- function(fsub, build_dir = tempfile(paste0(fsub@name, "-build-"))) {
 
 quickr_windows_add_dll_paths <- function(
   flags,
-  os_type = .Platform$OS.type,
-  config_value = quickr_cached_r_cmd_config_value,
-  which = Sys.which
+  os_type = .Platform$OS.type
 ) {
   if (!identical(os_type, "windows")) {
     return(invisible(character()))
@@ -359,15 +357,17 @@ quickr_windows_add_dll_paths <- function(
     file.path(arch_lib_dirs, "..", "..", "bin")
   )
 
-  config_binpref <- config_path(config_value("BINPREF"))
+  config_binpref <- config_path(
+    quickr_cached_r_cmd_config_value("BINPREF")
+  )
   if (nzchar(config_binpref) && !dir.exists(config_binpref)) {
     config_binpref <- dirname(config_binpref)
   }
   config_values <- c(
-    config_value("FC"),
-    config_value("F77"),
-    config_value("CC"),
-    config_value("CXX")
+    quickr_cached_r_cmd_config_value("FC"),
+    quickr_cached_r_cmd_config_value("F77"),
+    quickr_cached_r_cmd_config_value("CC"),
+    quickr_cached_r_cmd_config_value("CXX")
   )
   config_paths <- vapply(config_values, config_path, character(1))
   config_bins <- dirname(config_paths[nzchar(config_paths)])
@@ -406,7 +406,7 @@ quickr_windows_add_dll_paths <- function(
     file.path(rtools_roots, "x86_64-w64-mingw32", "bin")
   ))
 
-  compilers <- which(c("gfortran", "gcc", "clang", "flang"))
+  compilers <- Sys.which(c("gfortran", "gcc", "clang", "flang"))
   compilers <- compilers[nzchar(compilers)]
   compiler_bins <- unique(dirname(compilers))
 
@@ -457,13 +457,12 @@ quickr_windows_add_dll_paths <- function(
 
 quickr_windows_load_dll_dependencies <- function(
   dirs,
-  os_type = .Platform$OS.type,
-  dyn_load = base::dyn.load
+  os_type = .Platform$OS.type
 ) {
   if (!identical(os_type, "windows")) {
     return(invisible(character()))
   }
-  stopifnot(is.character(dirs), is.function(dyn_load))
+  stopifnot(is.character(dirs))
 
   patterns <- c(
     "libgcc_s*.dll",
@@ -486,7 +485,7 @@ quickr_windows_load_dll_dependencies <- function(
   dlls <- normalizePath(dlls, winslash = "\\", mustWork = FALSE)
   dlls <- dlls[!duplicated(tolower(basename(dlls)))]
   for (dll in dlls) {
-    dyn_load(dll)
+    base::dyn.load(dll)
   }
 
   invisible(dlls)

--- a/tests/testthat/test-compiler.R
+++ b/tests/testthat/test-compiler.R
@@ -31,71 +31,25 @@ local_empty_compiler_probe_cache <- function(envir = parent.frame()) {
   invisible(NULL)
 }
 
-test_that("quickr_r_cmd_config_value captures only stdout", {
-  expect_identical(
-    deparse(formals(quickr:::quickr_r_cmd_config_value)$system2),
-    "base::system2"
-  )
-
-  observed_stdout <- NULL
-  observed_stderr <- NULL
-  system2_stub <- function(
-    command,
-    args,
-    stdout = "",
-    stderr = "",
-    ...
-  ) {
-    observed_stdout <<- stdout
-    observed_stderr <<- stderr
-    " value "
-  }
-
-  expect_identical(
-    quickr:::quickr_r_cmd_config_value(
-      "CC",
-      r_cmd = "R",
-      system2 = system2_stub
-    ),
-    "value"
-  )
-  expect_identical(observed_stdout, TRUE)
-  expect_identical(observed_stderr, FALSE)
-})
-
-test_that("quickr_r_cmd_config_value returns empty on command failure", {
-  system2_stub <- function(command, args, stdout = "", stderr = "", ...) {
-    structure(" value ", status = 1L)
-  }
-
-  expect_identical(
-    quickr:::quickr_r_cmd_config_value(
-      "CC",
-      r_cmd = "R",
-      system2 = system2_stub
-    ),
-    ""
-  )
-})
-
 test_that("R CMD config probe distinguishes empty values from errors", {
-  empty_value <- function(...) character()
+  probe_value <- character()
+  local_mocked_bindings(
+    quickr_r_cmd = function() "R",
+    .package = "quickr"
+  )
+  local_mocked_bindings(
+    system2 = function(...) probe_value,
+    .package = "base"
+  )
+
   expect_identical(
-    quickr:::quickr_r_cmd_config_probe(
-      "CC",
-      r_cmd = "R",
-      system2 = empty_value
-    ),
+    quickr:::quickr_r_cmd_config_probe("CC"),
     list(value = "", ok = TRUE)
   )
 
-  error_value <- function(...) "ERROR: no information for variable 'CC'"
+  probe_value <- "ERROR: no information for variable 'CC'"
   expect_identical(
-    quickr:::quickr_r_cmd_config_probe(
-      "CC",
-      r_cmd = "R",
-      system2 = error_value
-    ),
+    quickr:::quickr_r_cmd_config_probe("CC"),
     list(value = "", ok = FALSE)
   )
 })
@@ -135,30 +89,28 @@ test_that("quickr_prefer_flang respects quickr.fortran_compiler", {
 })
 
 test_that("quickr_default_fortran_makevars_lines relaxes gfortran cost model", {
-  expect_equal(
-    quickr:::quickr_default_fortran_makevars_lines(
-      config_value = function(name) {
-        if (identical(name, "FC")) "gfortran -m64" else ""
-      }
-    ),
-    "PKG_FFLAGS += -fvect-cost-model=cheap"
+  fc <- "gfortran -m64"
+  local_mocked_bindings(
+    quickr_cached_r_cmd_config_value = function(name) {
+      if (identical(name, "FC")) fc else ""
+    },
+    .package = "quickr"
   )
 
   expect_equal(
-    quickr:::quickr_default_fortran_makevars_lines(
-      config_value = function(name) {
-        if (identical(name, "FC")) "/usr/bin/gfortran-13" else ""
-      }
-    ),
+    quickr:::quickr_default_fortran_makevars_lines(),
     "PKG_FFLAGS += -fvect-cost-model=cheap"
   )
 
+  fc <- "/usr/bin/gfortran-13"
+  expect_equal(
+    quickr:::quickr_default_fortran_makevars_lines(),
+    "PKG_FFLAGS += -fvect-cost-model=cheap"
+  )
+
+  fc <- "flang-new"
   expect_identical(
-    quickr:::quickr_default_fortran_makevars_lines(
-      config_value = function(name) {
-        if (identical(name, "FC")) "flang-new" else ""
-      }
-    ),
+    quickr:::quickr_default_fortran_makevars_lines(),
     character()
   )
 })
@@ -217,13 +169,17 @@ test_that("quickr_fcompiler_env writes Makevars when flang is usable", {
 test_that("quickr_fcompiler_env writes Makevars for default gfortran flags", {
   build_dir <- withr::local_tempdir()
 
+  local_mocked_bindings(
+    quickr_cached_r_cmd_config_value = function(name) {
+      if (identical(name, "FC")) "gfortran -m64" else ""
+    },
+    .package = "quickr"
+  )
+
   withr::local_options(quickr.fortran_compiler = "gfortran")
   env <- quickr:::quickr_fcompiler_env(
     build_dir = build_dir,
-    sysname = "Linux",
-    config_value = function(name) {
-      if (identical(name, "FC")) "gfortran -m64" else ""
-    }
+    sysname = "Linux"
   )
 
   expect_true(startsWith(env, "R_MAKEVARS_USER="))
@@ -384,14 +340,16 @@ test_that("quickr_fcompiler_env handles flang unavailable for non-explicit reque
     quickr_flang_available = function(...) {
       list(path = "/tmp/flang", available = FALSE)
     },
+    quickr_cached_r_cmd_config_value = function(name) {
+      if (identical(name, "FC")) "clang" else ""
+    },
     .package = "quickr"
   )
 
   # Should return character() since not explicit and flang unavailable
   result <- quickr:::quickr_fcompiler_env(
     build_dir = build_dir,
-    sysname = "Darwin",
-    config_value = function(name) if (identical(name, "FC")) "clang" else ""
+    sysname = "Darwin"
   )
   expect_identical(result, character())
 })
@@ -449,13 +407,15 @@ test_that("quickr_fcompiler_env falls back when flang runtime not found non-expl
     quickr_flang_available = function(...) {
       list(path = flang, available = TRUE)
     },
+    quickr_cached_r_cmd_config_value = function(name) {
+      if (identical(name, "FC")) "clang" else ""
+    },
     .package = "quickr"
   )
 
   result <- quickr:::quickr_fcompiler_env(
     build_dir = build_dir,
-    sysname = "Darwin",
-    config_value = function(name) if (identical(name, "FC")) "clang" else ""
+    sysname = "Darwin"
   )
   # Should fall back to character() since runtime not found and not explicit
   expect_identical(result, character())

--- a/tests/testthat/test-flang-preference.R
+++ b/tests/testthat/test-flang-preference.R
@@ -67,24 +67,21 @@ test_that("quickr_fcompiler_env returns empty when disabled or unavailable", {
   dir.create(build_dir)
   local_mocked_bindings(
     quickr_prefer_flang = function(...) FALSE,
+    quickr_cached_r_cmd_config_value = function(name) {
+      if (identical(name, "FC")) "clang" else ""
+    },
     .package = "quickr"
   )
 
   withr::local_options(quickr.fortran_compiler = "gfortran")
   expect_equal(
-    quickr:::quickr_fcompiler_env(
-      build_dir,
-      config_value = function(name) if (identical(name, "FC")) "clang" else ""
-    ),
+    quickr:::quickr_fcompiler_env(build_dir),
     character()
   )
 
   withr::local_options(quickr.fortran_compiler = "auto")
   expect_equal(
-    quickr:::quickr_fcompiler_env(
-      build_dir,
-      config_value = function(name) if (identical(name, "FC")) "clang" else ""
-    ),
+    quickr:::quickr_fcompiler_env(build_dir),
     character()
   )
 })

--- a/tests/testthat/test-internal-utils.R
+++ b/tests/testthat/test-internal-utils.R
@@ -191,12 +191,13 @@ test_that("iterable_is_singleton_one handles unknown iterable kinds", {
 })
 
 test_that("quickr_r_cmd adds .exe extension on Windows when needed", {
-  result <- quickr:::quickr_r_cmd(
-    os_type = "windows",
-    r_home = function(sub) "/path/to/R",
-    file_exists = function(x) FALSE
+  local_mocked_bindings(
+    file.exists = function(path) FALSE,
+    .package = "base"
   )
-  expect_equal(result, "/path/to/R.exe")
+
+  result <- quickr:::quickr_r_cmd(os_type = "windows")
+  expect_equal(result, paste0(R.home("bin/R"), ".exe"))
 })
 
 test_that("set_names handles list argument", {

--- a/tests/testthat/test-quick-windows-paths.R
+++ b/tests/testthat/test-quick-windows-paths.R
@@ -32,11 +32,20 @@ test_that("quickr_windows_add_dll_paths adds missing directories on Windows", {
     RTOOLS_HOME = ""
   ))
 
+  local_mocked_bindings(
+    quickr_cached_r_cmd_config_value = function(...) "",
+    .package = "quickr"
+  )
+  local_mocked_bindings(
+    Sys.which = function(cmds) {
+      setNames(file.path(compiler_dir, cmds), cmds)
+    },
+    .package = "base"
+  )
+
   res <- quickr:::quickr_windows_add_dll_paths(
     flags = c(paste0("-L", lib_dir)),
-    os_type = "windows",
-    config_value = function(...) "",
-    which = function(cmds) setNames(file.path(compiler_dir, cmds), cmds)
+    os_type = "windows"
   )
 
   expect_type(res, "character")
@@ -102,11 +111,18 @@ test_that("quickr_windows_add_dll_paths adds bin next to arch lib dirs", {
     RTOOLS_HOME = ""
   ))
 
+  local_mocked_bindings(
+    quickr_cached_r_cmd_config_value = function(...) "",
+    .package = "quickr"
+  )
+  local_mocked_bindings(
+    Sys.which = function(cmds) setNames(rep("", length(cmds)), cmds),
+    .package = "base"
+  )
+
   res <- quickr_windows_add_dll_paths(
     flags = c(paste0("-L", lib_arch_dir)),
-    os_type = "windows",
-    config_value = function(...) "",
-    which = function(cmds) setNames(rep("", length(cmds)), cmds)
+    os_type = "windows"
   )
 
   expect_type(res, "character")
@@ -143,11 +159,18 @@ test_that("quickr_windows_add_dll_paths skips unrelated grandparent bin dirs", {
     RTOOLS_HOME = ""
   ))
 
+  local_mocked_bindings(
+    quickr_cached_r_cmd_config_value = function(...) "",
+    .package = "quickr"
+  )
+  local_mocked_bindings(
+    Sys.which = function(cmds) setNames(rep("", length(cmds)), cmds),
+    .package = "base"
+  )
+
   res <- quickr_windows_add_dll_paths(
     flags = c(paste0("-L", lib_dir)),
-    os_type = "windows",
-    config_value = function(...) "",
-    which = function(cmds) setNames(rep("", length(cmds)), cmds)
+    os_type = "windows"
   )
 
   grandparent_bin_norm <- tolower(normalizePath(
@@ -191,11 +214,18 @@ test_that("quickr_windows_add_dll_paths adds usr/bin from Rtools link dirs", {
     RTOOLS_HOME = ""
   ))
 
+  local_mocked_bindings(
+    quickr_cached_r_cmd_config_value = function(...) "",
+    .package = "quickr"
+  )
+  local_mocked_bindings(
+    Sys.which = function(cmds) setNames(rep("", length(cmds)), cmds),
+    .package = "base"
+  )
+
   quickr_windows_add_dll_paths(
     flags = c(paste0("-L", lib_arch_dir)),
-    os_type = "windows",
-    config_value = function(...) "",
-    which = function(cmds) setNames(rep("", length(cmds)), cmds)
+    os_type = "windows"
   )
 
   path_entries <- strsplit(Sys.getenv("PATH"), ";", fixed = TRUE)[[1L]]
@@ -229,11 +259,18 @@ test_that("quickr_windows_add_dll_paths writes native Windows PATH entries", {
     RTOOLS_HOME = ""
   ))
 
+  local_mocked_bindings(
+    quickr_cached_r_cmd_config_value = function(...) "",
+    .package = "quickr"
+  )
+  local_mocked_bindings(
+    Sys.which = function(cmds) setNames(rep("", length(cmds)), cmds),
+    .package = "base"
+  )
+
   quickr_windows_add_dll_paths(
     flags = c(paste0("-L", lib_dir)),
-    os_type = "windows",
-    config_value = function(...) "",
-    which = function(cmds) setNames(rep("", length(cmds)), cmds)
+    os_type = "windows"
   )
 
   path_entries <- strsplit(Sys.getenv("PATH"), ";", fixed = TRUE)[[1L]]
@@ -272,16 +309,23 @@ test_that("quickr_windows_add_dll_paths adds BINPREF directories", {
     RTOOLS_HOME = ""
   ))
 
-  res <- quickr_windows_add_dll_paths(
-    flags = character(),
-    os_type = "windows",
-    config_value = function(name) {
+  local_mocked_bindings(
+    quickr_cached_r_cmd_config_value = function(name) {
       if (identical(name, "BINPREF")) {
         return(paste0(binpref, "/"))
       }
       ""
     },
-    which = function(cmds) setNames(rep("", length(cmds)), cmds)
+    .package = "quickr"
+  )
+  local_mocked_bindings(
+    Sys.which = function(cmds) setNames(rep("", length(cmds)), cmds),
+    .package = "base"
+  )
+
+  res <- quickr_windows_add_dll_paths(
+    flags = character(),
+    os_type = "windows"
   )
 
   expect_type(res, "character")
@@ -323,16 +367,26 @@ test_that("quickr_windows_add_dll_paths adds BINPREF prefix directories", {
     RTOOLS_HOME = ""
   ))
 
-  res <- quickr_windows_add_dll_paths(
-    flags = character(),
-    os_type = "windows",
-    config_value = function(name) {
+  local_mocked_bindings(
+    quickr_cached_r_cmd_config_value = function(name) {
       if (identical(name, "BINPREF")) {
-        return(file.path(binpref, "x86_64-w64-mingw32.static.posix-"))
+        return(file.path(
+          binpref,
+          "x86_64-w64-mingw32.static.posix-"
+        ))
       }
       ""
     },
-    which = function(cmds) setNames(rep("", length(cmds)), cmds)
+    .package = "quickr"
+  )
+  local_mocked_bindings(
+    Sys.which = function(cmds) setNames(rep("", length(cmds)), cmds),
+    .package = "base"
+  )
+
+  res <- quickr_windows_add_dll_paths(
+    flags = character(),
+    os_type = "windows"
   )
 
   expect_type(res, "character")
@@ -382,11 +436,20 @@ test_that("quickr_windows_add_dll_paths leaves PATH unchanged when complete", {
     RTOOLS_HOME = ""
   ))
 
+  local_mocked_bindings(
+    quickr_cached_r_cmd_config_value = function(...) "",
+    .package = "quickr"
+  )
+  local_mocked_bindings(
+    Sys.which = function(cmds) {
+      setNames(file.path(compiler_dir, cmds), cmds)
+    },
+    .package = "base"
+  )
+
   res <- quickr:::quickr_windows_add_dll_paths(
     flags = c(paste0("-L", lib_dir)),
-    os_type = "windows",
-    config_value = function(...) "",
-    which = function(cmds) setNames(file.path(compiler_dir, cmds), cmds)
+    os_type = "windows"
   )
 
   expect_type(res, "character")
@@ -411,16 +474,23 @@ test_that("quickr_windows_add_dll_paths returns post-update PATH order", {
     RTOOLS_HOME = ""
   ))
 
-  res <- quickr_windows_add_dll_paths(
-    flags = c(paste0("-L", lib_dir)),
-    os_type = "windows",
-    config_value = function(name) {
+  local_mocked_bindings(
+    quickr_cached_r_cmd_config_value = function(name) {
       if (identical(name, "FC")) {
         return(file.path(config_dir, "gfortran"))
       }
       ""
     },
-    which = function(cmds) setNames(rep("", length(cmds)), cmds)
+    .package = "quickr"
+  )
+  local_mocked_bindings(
+    Sys.which = function(cmds) setNames(rep("", length(cmds)), cmds),
+    .package = "base"
+  )
+
+  res <- quickr_windows_add_dll_paths(
+    flags = c(paste0("-L", lib_dir)),
+    os_type = "windows"
   )
 
   path_entries <- strsplit(Sys.getenv("PATH"), ";", fixed = TRUE)[[1L]]
@@ -464,11 +534,18 @@ test_that("quickr_windows_add_dll_paths excludes unrelated PATH directories", {
     RTOOLS_HOME = ""
   ))
 
+  local_mocked_bindings(
+    quickr_cached_r_cmd_config_value = function(...) "",
+    .package = "quickr"
+  )
+  local_mocked_bindings(
+    Sys.which = function(cmds) setNames(rep("", length(cmds)), cmds),
+    .package = "base"
+  )
+
   res <- quickr_windows_add_dll_paths(
     flags = c(paste0("-L", lib_dir)),
-    os_type = "windows",
-    config_value = function(...) "",
-    which = function(cmds) setNames(rep("", length(cmds)), cmds)
+    os_type = "windows"
   )
 
   res_norm <- tolower(normalizePath(res, winslash = "\\", mustWork = FALSE))
@@ -495,13 +572,17 @@ test_that("quickr_windows_load_dll_dependencies preloads known runtime DLLs", {
   )
 
   loaded <- character()
-  res <- quickr_windows_load_dll_dependencies(
-    c(lib_dir, bin_dir),
-    os_type = "windows",
-    dyn_load = function(path) {
+  local_mocked_bindings(
+    dyn.load = function(path) {
       loaded <<- c(loaded, path)
       structure(list(), class = "DLLInfo")
-    }
+    },
+    .package = "base"
+  )
+
+  res <- quickr_windows_load_dll_dependencies(
+    c(lib_dir, bin_dir),
+    os_type = "windows"
   )
 
   expected <- normalizePath(


### PR DESCRIPTION
## Summary

Remove obsolete dependency-injection arguments from the internal compiler and Windows toolchain helpers so their signatures match their production call paths after #119. Tests now replace quickr and base namespace bindings with `local_mocked_bindings()`.

## User-facing changes

None. This changes no public API or behavior.

## Internal changes

- Delete the unused `quickr_r_cmd_config_value()` wrapper.
- Call compiler configuration, process, filesystem, and DLL-loading bindings directly while retaining the existing platform overrides.
- Preserve public compilation coverage for successful configuration-cache reuse and retry after failed probes.

## Validation

- `air format .`
- `R -q -e 'devtools::test(filter = "compiler|flang-preference|internal-utils|quick-windows-paths")'`
- `R -q -e 'devtools::test()'` — 1,726 passed
- `R -q -e 'rcmdcheck::rcmdcheck(error_on = "warning")'` — 0 errors, 0 warnings; one `.git` package-structure note
