### PR TITLE
Cache successful flang availability probes

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,9 @@
   for the rest of the R session. Restart R after changing the compiler or
   Makevars configuration.
 
+* Successful flang availability checks are now reused for the rest of the R
+  session. Restart R after changing the flang toolchain.
+
 # quickr 0.3.0
 
 This release adds major new support for linear algebra, local functions,

--- a/R/compiler.R
+++ b/R/compiler.R
@@ -15,6 +15,20 @@ quickr_flang_available <- function() {
   if (!nzchar(flang)) {
     return(list(path = "", available = FALSE))
   }
+
+  # Compiler availability is fixed for the R session. Restart R after
+  # changing the flang toolchain.
+  cache_key <- paste("flang_available", flang, sep = "\r")
+  if (
+    exists(
+      cache_key,
+      envir = quickr_compiler_probe_cache,
+      inherits = FALSE
+    )
+  ) {
+    return(list(path = flang, available = TRUE))
+  }
+
   probe <- tryCatch(
     system2(flang, "--version", stdout = TRUE, stderr = TRUE),
     error = function(e) structure(character(), status = 1L)
@@ -22,6 +36,7 @@ quickr_flang_available <- function() {
   if (!is.null(attr(probe, "status"))) {
     return(list(path = flang, available = FALSE))
   }
+  assign(cache_key, TRUE, envir = quickr_compiler_probe_cache)
   list(path = flang, available = TRUE)
 }
 

--- a/tests/testthat/test-compiler.R
+++ b/tests/testthat/test-compiler.R
@@ -534,3 +534,94 @@ test_that("quick retries failed R CMD config probes", {
   expect_quick_identical(fn, 3)
   expect_identical(blas_calls, 2L)
 })
+
+test_that("quick caches successful flang probes by resolved path", {
+  local_empty_compiler_probe_cache()
+  withr::local_options(quickr.fortran_compiler = "auto")
+
+  flang <- file.path(tempdir(), "flang-one")
+  real_system2 <- base::system2
+  real_sys_info <- base::Sys.info
+  probes <- character()
+  local_mocked_bindings(
+    quickr_flang_path = function() flang,
+    .package = "quickr"
+  )
+  local_mocked_bindings(
+    Sys.info = function() {
+      info <- real_sys_info()
+      info[["sysname"]] <- "Darwin"
+      info
+    },
+    system2 = function(command, args = character(), ...) {
+      if (identical(command, flang) && identical(args, "--version")) {
+        probes <<- c(probes, command)
+        return("flang version")
+      }
+      real_system2(command, args, ...)
+    },
+    .package = "base"
+  )
+
+  fn <- function(x) {
+    declare(type(x = double(1)))
+    x + 1
+  }
+
+  compiled <- quick(fn)
+  expect_identical(compiled(1), 2)
+  compiled <- quick(fn)
+  expect_identical(compiled(2), 3)
+
+  flang <- file.path(tempdir(), "flang-two")
+  compiled <- quick(fn)
+  expect_identical(compiled(3), 4)
+
+  expect_identical(
+    probes,
+    c(
+      file.path(tempdir(), "flang-one"),
+      file.path(tempdir(), "flang-two")
+    )
+  )
+})
+
+test_that("quick retries failed flang probes", {
+  local_empty_compiler_probe_cache()
+  withr::local_options(quickr.fortran_compiler = "auto")
+
+  flang <- file.path(tempdir(), "flang")
+  real_system2 <- base::system2
+  real_sys_info <- base::Sys.info
+  probes <- 0L
+  local_mocked_bindings(
+    quickr_flang_path = function() flang,
+    .package = "quickr"
+  )
+  local_mocked_bindings(
+    Sys.info = function() {
+      info <- real_sys_info()
+      info[["sysname"]] <- "Darwin"
+      info
+    },
+    system2 = function(command, args = character(), ...) {
+      if (identical(command, flang) && identical(args, "--version")) {
+        probes <<- probes + 1L
+        return(structure("flang error", status = 1L))
+      }
+      real_system2(command, args, ...)
+    },
+    .package = "base"
+  )
+
+  fn <- function(x) {
+    declare(type(x = double(1)))
+    x + 1
+  }
+
+  compiled <- quick(fn)
+  expect_identical(compiled(1), 2)
+  compiled <- quick(fn)
+  expect_identical(compiled(2), 3)
+  expect_identical(probes, 2L)
+})


### PR DESCRIPTION
## User-facing change

Repeated `quick()` compilations with automatic compiler selection now reuse a
successful flang availability check for the rest of the R session. This removes
repeated `flang --version` calls from compiler setup. Restart R after changing
the flang toolchain.

Failed availability checks are still retried on the next compilation.

## Internal implementation

`quickr_flang_available()` stores successful results in the existing
session-local `quickr_compiler_probe_cache`, keyed by the path returned from
flang resolution. A different resolved path receives a separate cache entry.

The regression tests exercise repeated compilations through `quick()`, call the
generated functions, and cover successful reuse, path-specific entries, and
failed-probe retries.

## Benchmark

The benchmark used automatic compiler selection with Homebrew flang 22.1.8 at
`/opt/homebrew/bin/flang-new`. Seven fresh R processes each compiled and called
the same scalar function six times. Probe counting intercepted only the exact
`flang --version` call and delegated every compilation command to the real
`base::system2()`.

| Source | Median wall time | Range | flang probes per process |
| --- | ---: | ---: | ---: |
| `origin/main` (`f6d0f3f`) | 6.663 s | 6.470–6.948 s | 12 |
| This branch | 5.983 s | 5.288–6.216 s | 1 |

This is a 1.11x speedup, or a 10.2% reduction in median wall time.

## Tests

- `R -q -e 'devtools::test(filter = "compiler|flang")'`
- `R -q -e 'devtools::test()'`
- `R -q -e 'rcmdcheck::rcmdcheck(error_on = "warning")'` (0 errors, 0 warnings;
  the existing `.git` worktree NOTE remains)
