### PR TITLE
[1/15] Fix repeated side effects in floor/ceiling and runif bounds, reject na.rm= in reductions, and three small crash/diagnostic fixes

### DIFF
--- a/R/classes.R
+++ b/R/classes.R
@@ -240,6 +240,9 @@ Variable := new_class(
       NULL | class_list,
       setter = function(self, value) {
         if (!length(value)) {
+          # reset to scalar (NULL means scalar); assign the attribute
+          # directly to avoid recursing through this setter
+          attr(self, "dims") <- NULL
           return(self)
         }
 

--- a/R/r2f-aab-core.R
+++ b/R/r2f-aab-core.R
@@ -71,6 +71,26 @@ new_hoist <- function(scope) {
   )
 }
 
+# Hoist `x` into a temporary variable unless it already renders as a bare
+# variable name. Use this whenever the same operand is spliced into generated
+# code more than once: Fortran evaluates intrinsic actual arguments before the
+# call, so repeating an expression duplicates its side effects (e.g. RNG
+# state via runif()).
+hoist_unless_name <- function(x, hoist) {
+  stopifnot(inherits(x, Fortran), inherits(x@value, Variable))
+  code <- trimws(as.character(x))
+  if (!is.null(x@value@name) && identical(code, x@value@name)) {
+    return(x)
+  }
+  tmp <- hoist$declare_tmp(
+    mode = x@value@mode,
+    dims = x@value@dims,
+    logical_as_int = logical_as_int(x@value)
+  )
+  hoist$emit(glue("{tmp@name} = {x}"))
+  Fortran(tmp@name, tmp)
+}
+
 
 # --- Scope Helpers ---
 

--- a/R/r2f-assign.R
+++ b/R/r2f-assign.R
@@ -175,6 +175,14 @@ register_r2f_handler(
     if (!existing_binding) {
       # The var does not exist -> this is a binding to a new symbol
       # Create a fresh Variable carrying only mode/dims and a new name.
+      if (inherits(value, Fortran) && is.null(value@value)) {
+        stop(
+          "cannot assign `",
+          deparse1(rhs),
+          "`: expression does not produce a value",
+          call. = FALSE
+        )
+      }
       if (!inherits(var, Variable)) {
         src <- value@value
         var <- Variable(mode = src@mode, dims = src@dims)

--- a/R/r2f-constructors.R
+++ b/R/r2f-constructors.R
@@ -157,24 +157,10 @@ r2f_handlers[["matrix"]] <- function(args, scope = NULL, ..., hoist = NULL) {
 
   rows <- dims[[1L]]
   cols <- dims[[2L]]
-  source <- glue("{src}")
 
   # Avoid double-evaluating non-trivial expressions when used in both the
-  # `source` and `pad` args. In Fortran, intrinsic actual args are evaluated
-  # before the call, so repeating the expression can duplicate side effects
-  # (e.g. RNG state via runif()).
-  if (
-    is.null(src@value@name) ||
-      !identical(trimws(source), src@value@name)
-  ) {
-    tmp <- hoist$declare_tmp(
-      mode = src@value@mode,
-      dims = src@value@dims,
-      logical_as_int = logical_as_int(src@value)
-    )
-    hoist$emit(glue("{tmp@name} = {src}"))
-    source <- tmp@name
-  }
+  # `source` and `pad` args.
+  source <- glue("{hoist_unless_name(src, hoist)}")
   Fortran(
     glue(
       "reshape({source}, [{bind_dim_int(rows)}, {bind_dim_int(cols)}], pad = {source})"

--- a/R/r2f-math.R
+++ b/R/r2f-math.R
@@ -42,10 +42,13 @@ register_unary_intrinsic(
   expr_fun = function(arg, intrinsic) glue("{intrinsic}({arg})")
 )
 
-r2f_handlers[["floor"]] <- function(args, scope, ...) {
+r2f_handlers[["floor"]] <- function(args, scope, ..., hoist = NULL) {
   stopifnot(length(args) == 1L)
-  arg <- r2f(args[[1L]], scope, ...)
+  arg <- r2f(args[[1L]], scope, ..., hoist = hoist)
 
+  # `arg` is spliced into the emitted expression three times below; hoist
+  # non-trivial expressions so side effects (e.g. RNG state) happen once.
+  arg <- hoist_unless_name(arg, hoist)
   arg <- maybe_cast_double(arg)
   if (!identical(arg@value@mode, "double")) {
     stop("floor() only implemented for logical, integer, and double")
@@ -63,10 +66,13 @@ r2f_handlers[["floor"]] <- function(args, scope, ...) {
   )
 }
 
-r2f_handlers[["ceiling"]] <- function(args, scope, ...) {
+r2f_handlers[["ceiling"]] <- function(args, scope, ..., hoist = NULL) {
   stopifnot(length(args) == 1L)
-  arg <- r2f(args[[1L]], scope, ...)
+  arg <- r2f(args[[1L]], scope, ..., hoist = hoist)
 
+  # `arg` is spliced into the emitted expression three times below; hoist
+  # non-trivial expressions so side effects (e.g. RNG state) happen once.
+  arg <- hoist_unless_name(arg, hoist)
   arg <- maybe_cast_double(arg)
   if (!identical(arg@value@mode, "double")) {
     stop("ceiling() only implemented for logical, integer, and double")

--- a/R/r2f-random.R
+++ b/R/r2f-random.R
@@ -14,14 +14,22 @@ r2f_handlers[["runif"]] <- function(args, scope, ..., hoist = NULL) {
   default_min <- identical(min, 0) || identical(min, 0L)
   default_max <- identical(max, 1) || identical(max, 1L)
 
+  # R evaluates runif() bounds exactly once, but `min` is spliced twice below
+  # and the implied-do re-evaluates the whole expression per element; hoist
+  # non-trivial bounds (e.g. an impure runif(1)) so they are evaluated once.
+  bound <- function(r_arg) {
+    b <- r2f(r_arg, scope, ..., hoist = hoist)
+    if (is.atomic(r_arg)) b else hoist_unless_name(b, hoist)
+  }
+
   if (default_min && default_max) {
     get1rand <- "unif_rand()"
   } else if (default_min) {
-    max <- r2f(max, scope, ..., hoist = hoist)
+    max <- bound(max)
     get1rand <- glue("unif_rand() * {max}")
   } else {
-    max <- r2f(max, scope, ..., hoist = hoist)
-    min <- r2f(min, scope, ..., hoist = hoist)
+    min <- bound(min)
+    max <- bound(max)
     get1rand <- glue("({min} + (unif_rand() * ({max} - {min})))")
   }
 

--- a/R/r2f-reductions.R
+++ b/R/r2f-reductions.R
@@ -13,6 +13,16 @@ register_r2f_handler(
     scope,
     ...
   ) {
+    # Named arguments like `na.rm` would otherwise be treated as data
+    # arguments (e.g. `sum(x, na.rm = TRUE)` -> `(sum(x) + .true.)`).
+    arg_names <- names(args) %||% character()
+    if (length(arg_names) && any(nzchar(arg_names))) {
+      stop(
+        "max()/min()/sum()/prod() do not support named arguments (e.g. `na.rm`)",
+        call. = FALSE
+      )
+    }
+
     intrinsic <- switch(
       last(list(...)$calls),
       max = "maxval",

--- a/R/sizes.R
+++ b/R/sizes.R
@@ -168,7 +168,8 @@ r2size <- function(r, scope) {
         if (!inherits(var, Variable)) {
           stop("could not resolve size: ", as.character(r))
         }
-        if (var@mode != "integer" || !passes_as_scalar(var)) {
+        # !identical(): @mode can be NULL (deferred-mode binding)
+        if (!identical(var@mode, "integer") || !passes_as_scalar(var)) {
           warning("size is not an integer:", as.character(r))
         }
         if (var@is_arg && !var@modified) {

--- a/tests/testthat/_snaps/example-convolve.md
+++ b/tests/testthat/_snaps/example-convolve.md
@@ -10,7 +10,7 @@
           ab <- double(length(a) + length(b) - 1)
           for (i in seq_along(a)) {
             for (j in seq_along(b)) {
-              ab[i + j - 1] = ab[i + j - 1] + a[i] * b[j]
+              ab[i + j - 1] <- ab[i + j - 1] + a[i] * b[j]
             }
           }
           ab

--- a/tests/testthat/_snaps/hoist-unless-name.md
+++ b/tests/testthat/_snaps/hoist-unless-name.md
@@ -1,0 +1,61 @@
+# floor() hoists non-name arguments to a temporary
+
+    Code
+      fn
+    Output
+      function() {
+          out <- floor(runif(1L) * 10)
+          out
+        }
+      <environment: 0x0>
+    Code
+      cat(fsub)
+    Output
+      subroutine fn(out) bind(c)
+        use iso_c_binding, only: c_double
+        implicit none
+      
+        ! manifest start
+        ! args
+        real(c_double), intent(out) :: out
+        ! manifest end
+      
+        interface
+          function unif_rand() bind(c, name = "unif_rand") result(u)
+            use iso_c_binding, only: c_double
+            real(c_double) :: u
+          end function unif_rand
+        end interface
+      
+        block
+          real(c_double) :: btmp1_
+      
+          btmp1_ = (unif_rand() * 10.0_c_double)
+          out = (aint(btmp1_) - merge(1.0_c_double, 0.0_c_double, (btmp1_ < aint(btmp1_))))
+        end block
+      end subroutine
+    Code
+      cat(cwrapper)
+    Output
+      #define R_NO_REMAP
+      #include <R.h>
+      #include <Rinternals.h>
+      #include <R_ext/Random.h>
+      
+      
+      extern void fn(double* const out__);
+      
+      SEXP fn_(SEXP _args) {
+        
+        const R_xlen_t out__len_ = (1);
+        SEXP out = PROTECT(Rf_allocVector(REALSXP, out__len_));
+        double* out__ = REAL(out);
+        
+        GetRNGstate();
+        fn(out__);
+        PutRNGstate();
+        
+        UNPROTECT(1);
+        return out;
+      }
+

--- a/tests/testthat/_snaps/loops.md
+++ b/tests/testthat/_snaps/loops.md
@@ -144,7 +144,7 @@
       function(x) {
           declare(type(x = integer(1)))
           for (i in 1:10) {
-            x = x + 1L
+            x <- x + 1L
             if (x >= 5L) {
               break
             }
@@ -214,7 +214,7 @@
       function(x) {
           declare(type(x = integer(1)))
           while (x < 5L) {
-            x = x + 1L
+            x <- x + 1L
           }
           x
         }

--- a/tests/testthat/_snaps/runif.md
+++ b/tests/testthat/_snaps/runif.md
@@ -566,3 +566,67 @@
         return out_;
       }
 
+# impure runif() bounds are evaluated exactly once
+
+    Code
+      fn
+    Output
+      function() {
+          out <- runif(2L, runif(1L), 10)
+          out
+        }
+      <environment: 0x0>
+    Code
+      cat(fsub)
+    Output
+      subroutine fn(out) bind(c)
+        use iso_c_binding, only: c_double, c_int
+        implicit none
+      
+        ! manifest start
+        ! args
+        real(c_double), intent(out) :: out(2)
+      
+        ! locals
+        integer(c_int) :: tmp1_
+        ! manifest end
+      
+        interface
+          function unif_rand() bind(c, name = "unif_rand") result(u)
+            use iso_c_binding, only: c_double
+            real(c_double) :: u
+          end function unif_rand
+        end interface
+      
+        block
+          real(c_double) :: btmp1_
+      
+          btmp1_ = unif_rand()
+          out = [((btmp1_ + (unif_rand() * (10.0_c_double - btmp1_))), tmp1_=1, 2)]
+        end block
+      end subroutine
+    Code
+      cat(cwrapper)
+    Output
+      #define R_NO_REMAP
+      #include <R.h>
+      #include <Rinternals.h>
+      #include <R_ext/Random.h>
+      
+      
+      extern void fn(double* const out__);
+      
+      SEXP fn_(SEXP _args) {
+        
+        const R_xlen_t out__len_ = 2;
+        SEXP out = PROTECT(Rf_allocVector(REALSXP, out__len_));
+        double* out__ = REAL(out);
+        
+        GetRNGstate();
+        fn(out__);
+        PutRNGstate();
+        
+        UNPROTECT(1);
+        return out;
+      }
+

--- a/tests/testthat/_snaps/size-constraint.md
+++ b/tests/testthat/_snaps/size-constraint.md
@@ -5,7 +5,7 @@
     Output
       function(a, b) {
           declare(type(a = double(n)), type(b = double(n + 1)))
-          a = sum(b)
+          a <- sum(b)
           a
         }
       <environment: 0x0>

--- a/tests/testthat/test-classes.R
+++ b/tests/testthat/test-classes.R
@@ -109,3 +109,11 @@ test_that("new_setter errors for invalid coerce argument", {
     "coerce must be TRUE, FALSE, NULL"
   )
 })
+
+test_that("Variable@dims can be reset to scalar with NULL", {
+  v <- quickr:::Variable("double", list(2L, 3L))
+  expect_identical(v@dims, list(2L, 3L))
+  v@dims <- NULL
+  expect_null(v@dims)
+  expect_true(v@is_scalar)
+})

--- a/tests/testthat/test-errors.R
+++ b/tests/testthat/test-errors.R
@@ -185,3 +185,16 @@ test_that("reductions reject named arguments like na.rm", {
   }
 })
 
+
+test_that("assigning an expression that produces no value errors cleanly", {
+  fn <- function(x) {
+    declare(type(x = logical(1)))
+    y <- if (x) 1 else 2
+    y
+  }
+  expect_error(
+    quick(fn),
+    "cannot assign `if (x) 1 else 2`: expression does not produce a value",
+    fixed = TRUE
+  )
+})

--- a/tests/testthat/test-errors.R
+++ b/tests/testthat/test-errors.R
@@ -169,3 +169,19 @@ test_that("declare() type() calls validate syntax", {
     fixed = TRUE
   )
 })
+
+test_that("reductions reject named arguments like na.rm", {
+  for (reducer in c("max", "min", "sum", "prod")) {
+    fn <- eval(bquote(function(x) {
+      declare(type(x = double(NA)))
+      out <- .(as.name(reducer))(x, na.rm = TRUE)
+      out
+    }))
+    expect_error(
+      quick(fn),
+      "do not support named arguments",
+      fixed = TRUE
+    )
+  }
+})
+

--- a/tests/testthat/test-example-convolve.R
+++ b/tests/testthat/test-example-convolve.R
@@ -11,7 +11,7 @@ test_that("convolve", {
     ab <- double(length(a) + length(b) - 1)
     for (i in seq_along(a)) {
       for (j in seq_along(b)) {
-        ab[i + j - 1] = ab[i + j - 1] + a[i] * b[j]
+        ab[i + j - 1] <- ab[i + j - 1] + a[i] * b[j]
       }
     }
     ab

--- a/tests/testthat/test-hoist-unless-name.R
+++ b/tests/testthat/test-hoist-unless-name.R
@@ -1,0 +1,62 @@
+# floor()/ceiling() splice their argument into the emitted expression three
+# times; non-trivial arguments must be hoisted to a temporary so side effects
+# (e.g. RNG state) happen exactly once.
+
+skip_on_cran()
+
+test_that("floor() does not evaluate an impure argument multiple times", {
+  fn <- function() {
+    out <- floor(runif(1L) * 10)
+    out
+  }
+  qfn <- quick(fn)
+
+  set.seed(1234)
+  q_res <- qfn()
+  q_next <- runif(1L)
+
+  set.seed(1234)
+  r_res <- fn()
+  r_next <- runif(1L)
+
+  expect_identical(q_res, r_res)
+  expect_equal(q_next, r_next)
+})
+
+test_that("ceiling() does not evaluate an impure argument multiple times", {
+  fn <- function() {
+    out <- ceiling(runif(1L) * 10)
+    out
+  }
+  qfn <- quick(fn)
+
+  set.seed(1234)
+  q_res <- qfn()
+  q_next <- runif(1L)
+
+  set.seed(1234)
+  r_res <- fn()
+  r_next <- runif(1L)
+
+  expect_identical(q_res, r_res)
+  expect_equal(q_next, r_next)
+})
+
+test_that("floor() hoists non-name arguments to a temporary", {
+  fn <- function() {
+    out <- floor(runif(1L) * 10)
+    out
+  }
+  expect_translation_snapshots(fn)
+})
+
+test_that("floor()/ceiling() on a bare variable emit no temporary", {
+  fn <- function(x) {
+    declare(type(x = double(NA)))
+    out <- floor(x) + ceiling(x)
+    out
+  }
+  fsub <- r2f(fn)
+  expect_no_match(fsub, "block", fixed = TRUE)
+  expect_quick_identical(fn, list(c(-2.5, -1, 0.5, 3)))
+})

--- a/tests/testthat/test-internal-utils.R
+++ b/tests/testthat/test-internal-utils.R
@@ -245,3 +245,14 @@ test_that("check_assignment_compatible handles NULL value", {
   target <- quickr:::Variable("double", list(1L))
   expect_silent(quickr:::check_assignment_compatible(target, NULL))
 })
+
+test_that("r2size() warns, not crashes, on a deferred-mode Variable", {
+  # mirrors R/r2f-assign.R's deferred-mode path: a binding can exist with
+  # @mode still NULL while inference is in progress
+  scope <- quickr:::new_scope(closure = NULL)
+  scope[["n"]] <- quickr:::Variable(NULL, name = "n", r_name = "n")
+  expect_warning(
+    quickr:::r2size(quote(n), scope),
+    "size is not an integer"
+  )
+})

--- a/tests/testthat/test-loops.R
+++ b/tests/testthat/test-loops.R
@@ -39,7 +39,7 @@ test_that("break/for", {
   fn <- function(x) {
     declare(type(x = integer(1)))
     for (i in 1:10) {
-      x = x + 1L
+      x <- x + 1L
       if (x >= 5L) {
         break
       }
@@ -55,7 +55,7 @@ test_that("while", {
   fn <- function(x) {
     declare(type(x = integer(1)))
     while (x < 5L) {
-      x = x + 1L
+      x <- x + 1L
     }
     x
   }

--- a/tests/testthat/test-runif.R
+++ b/tests/testthat/test-runif.R
@@ -117,3 +117,28 @@ test_that("runif with min/max", {
     set_seed_and_call(qfn, 20)
   )
 })
+
+test_that("impure runif() bounds are evaluated exactly once", {
+  # `min` is spliced twice into the emitted expression, and the implied-do
+  # for array results would re-evaluate spliced bounds per element; R
+  # evaluates bounds once per call.
+  fn <- function() {
+    out <- runif(2L, runif(1L), 10)
+    out
+  }
+  expect_translation_snapshots(fn)
+  qfn <- quick(fn)
+
+  expect_identical(
+    set_seed_and_call(fn),
+    set_seed_and_call(qfn)
+  )
+
+  set.seed(1)
+  qfn()
+  q_next <- runif(1L)
+  set.seed(1)
+  fn()
+  r_next <- runif(1L)
+  expect_identical(q_next, r_next)
+})

--- a/tests/testthat/test-size-constraint.R
+++ b/tests/testthat/test-size-constraint.R
@@ -5,7 +5,7 @@ skip_on_cran()
 test_that("size constraint", {
   fn <- function(a, b) {
     declare(type(a = double(n)), type(b = double(n + 1)))
-    a = sum(b)
+    a <- sum(b)
     a
   }
 


### PR DESCRIPTION
> **Stacked PR 1 of 15** — branch
> `conformability/01-side-effects-and-crashes`, cut from `main`. It is the
> base of the series, so this diff is its own work only. Later PRs in the
> series stack on top of it.
>
> Stack overview and suggested review order: #152.

Fixes #122.

## What changed

Six small, independent fixes, one commit each (plus a final formatting-only
commit, see notes):

1. **`floor()` / `ceiling()` now evaluate their argument exactly once.**
   Previously the argument expression was spliced into the emitted Fortran
   three times, so `floor(runif(1) * 10)` mixed two different random draws
   and advanced the RNG state three times. Non-trivial arguments are now
   hoisted to a block temporary:

   ```fortran
   ! before
   out = (aint((unif_rand() * 10.0_c_double)) - merge(1.0_c_double, 0.0_c_double, &
     ((unif_rand() * 10.0_c_double) < aint((unif_rand() * 10.0_c_double)))))

   ! after
   block
     real(c_double) :: btmp1_
     btmp1_ = (unif_rand() * 10.0_c_double)
     out = (aint(btmp1_) - merge(1.0_c_double, 0.0_c_double, (btmp1_ < aint(btmp1_))))
   end block
   ```

   Bare variable names are passed through unchanged, so side-effect-free
   translations are unaffected.

2. **`runif()` bounds are now evaluated exactly once** — same defect class:
   `min` was spliced twice, and for array results the implied-do re-evaluated
   spliced bounds once per element, so `runif(2L, runif(1L), 10)` drew a
   fresh "min" repeatedly where R evaluates it once:

   ```fortran
   ! before
   out = [((unif_rand() + (unif_rand() * (10.0_c_double - unif_rand()))), tmp1_=1, 2)]

   ! after
   block
     real(c_double) :: btmp1_
     btmp1_ = unif_rand()
     out = [((btmp1_ + (unif_rand() * (10.0_c_double - btmp1_))), tmp1_=1, 2)]
   end block
   ```

   Bare-name and literal bounds are unaffected (no new temporaries).

3. **`max()`/`min()`/`sum()`/`prod()` now reject named arguments** with a
   compile-time error. Previously `sum(x, na.rm = TRUE)` treated
   `na.rm = TRUE` as a data argument and emitted `(sum(x) + .true.)`, failing
   later at the gfortran stage with an inscrutable type error (or, where the
   operand typed through, computing the wrong thing). This matches the
   existing `any()`/`all()` guard.

4. **Assigning an expression that produces no value errors cleanly.**
   `y <- if (x) 1 else 2` (a value-less statement in the lowering) previously
   crashed with ``no applicable method for `@` applied to an object of class
   "NULL"``; it now errors with
   ``cannot assign `if (x) 1 else 2`: expression does not produce a value``.

5. **`r2size()` no longer crashes on a variable whose mode is still being
   inferred** (`@mode` NULL): `var@mode != "integer"` yielded `logical(0)`, the
   enclosing `||` collapsed to `NA`, and `if` aborted with "missing value where
   TRUE/FALSE needed". `!identical(var@mode, "integer")` reaches the intended
   warning path.

6. **`Variable@dims <- NULL` now resets the variable to scalar** per the
   class's documented "NULL means scalar" convention, instead of being a
   silent no-op that kept stale dims. (`r2f-assign.R`'s mode-inference
   reassignment path assigns `var@dims <- value@value@dims`, where a
   legitimately-NULL right-hand side means scalar.)

## How

- New shared helper `hoist_unless_name(x, hoist)` in `R/r2f-aab-core.R`
  (next to `new_hoist()`), extracted from the `matrix()` handler's existing
  hoist-to-temporary logic; `matrix()` now uses it, and `floor()`/`ceiling()`
  (`R/r2f-math.R`) and the `runif()` bounds (`R/r2f-random.R`) call it before
  splicing. Other handlers that splice an operand more than once can adopt it
  incrementally (`rev()` already hoists inline with the same pattern).

  The helper skips the temporary only for a bare variable name, so it
  over-hoists **literals** — `floor(2.5)` now spends a temporary it does not
  need. That is deliberate here: teaching it about literals changes emitted
  code for every existing caller, which would churn snapshots in a PR whose
  point is a targeted correctness fix. `runif()` takes a local
  `is.atomic()` shortcut to avoid the worst of it. PR 13 removes both the
  over-hoisting and the shortcut, in a PR where the snapshot churn is the
  expected content.
- `R/r2f-reductions.R`: named-argument guard at the top of the
  max/min/sum/prod handler, copied from any/all.
- `R/r2f-assign.R`: NULL-`@value` check in the new-binding path.
- `R/sizes.R`: `!identical(var@mode, "integer")`.
- `R/classes.R`: the `dims` setter assigns the attribute directly on empty
  input (same S7 workaround as the `r` property) instead of early-returning.

## Tests

- `test-hoist-unless-name.R` (new): floor/ceiling with `runif(1)` arguments
  match R under a fixed seed and leave the RNG state identical to R's; a
  translation snapshot pins the single-`unif_rand` form; a bare-variable case
  asserts no temporary is emitted.
- `test-errors.R`: compile-time rejection of `na.rm =` for all four
  reductions; the clean void-assignment diagnostic.
- `test-runif.R`: `runif(2L, runif(1L), 10)` matches R under a fixed seed
  with identical RNG state after the call; translation snapshot pins the
  hoisted bound.
- `test-internal-utils.R`: `r2size()` warns instead of crashing on a
  deferred-mode variable.
- `test-classes.R`: `@dims <- NULL` yields `is_scalar`.

Snapshot churn: only the new `_snaps/hoist-unless-name.md` and an added case
in `_snaps/runif.md`. No existing snapshots change (floor/ceiling on bare names, the dominant case in the
suite, are untouched).

## Notes for review

- The floor/ceiling hoist happens *before* the double-cast, so an integer
  bare name still splices as `real(x, kind=c_double)` (pure) without a
  temporary; only genuinely non-trivial expressions pay for one.
- The last commit is formatting-only (`air format`): `=` assignment becomes
  `<-` in three pre-existing test files (`test-example-convolve.R`,
  `test-loops.R`, `test-size-constraint.R`). No behavior change.
- `test-internal-utils.R`'s "print.quickr_ordered_env outputs bindings" test
  fails on a clean checkout of `main` in my environment (R-version-dependent
  `capture.output`/`str` behavior, unrelated to this change) — called out so
  it isn't attributed to this PR.
- No NEWS entry added; happy to add one if you'd like these user-visible
  diagnostics mentioned.