### PR TITLE
[2/15] Fix wrong-kind literals and kind-less casts in logical division, integer `%/%`, and `Re()`

### DIFF
--- a/R/r2f-arithmetic.R
+++ b/R/r2f-arithmetic.R
@@ -83,7 +83,9 @@ r2f_handlers[["%/%"]] <- function(args, scope, ...) {
 
   expr <- switch(
     out_val@mode,
-    integer = glue("int(floor(real({left}) / real({right})))"),
+    integer = glue(
+      "int(floor(real({left}, kind=c_double) / real({right}, kind=c_double)), kind=c_int)"
+    ),
     double = glue("floor({left} / {right})"),
     stop("%/% only implemented for numeric types")
   )

--- a/R/r2f-math.R
+++ b/R/r2f-math.R
@@ -131,7 +131,9 @@ r2f_handlers[["abs"]] <- function(args, scope, ...) {
 register_unary_intrinsic(
   "Re",
   mode_fun = function(arg) "double",
-  expr_fun = function(arg, intrinsic) glue("real({arg})")
+  # kind-less real() of an integer or double argument is single precision;
+  # kind=c_double is a no-op change of meaning for complex arguments (F2018).
+  expr_fun = function(arg, intrinsic) glue("real({arg}, kind=c_double)")
 )
 
 register_unary_intrinsic(

--- a/R/r2f-operators-helpers.R
+++ b/R/r2f-operators-helpers.R
@@ -30,7 +30,7 @@ booleanize_logical_as_int <- function(x) {
 maybe_cast_double <- function(x) {
   if (x@value@mode == "logical") {
     Fortran(
-      glue("merge(1_c_double, 0_c_double, {x})"),
+      glue("merge(1.0_c_double, 0.0_c_double, {x})"),
       Variable("double", x@value@dims)
     )
   } else if (x@value@mode == "integer") {

--- a/tests/testthat/_snaps/div-cast.md
+++ b/tests/testthat/_snaps/div-cast.md
@@ -188,7 +188,7 @@
         ! manifest end
       
       
-        out_ = (a / merge(1_c_double, 0_c_double, (b/=0)))
+        out_ = (a / merge(1.0_c_double, 0.0_c_double, (b/=0)))
       end subroutine
     Code
       cat(cwrapper)
@@ -236,6 +236,81 @@
           b__,
           out___,
           a__len_);
+        
+        UNPROTECT(1);
+        return out_;
+      }
+
+# division casts logical by logical
+
+    Code
+      fn
+    Output
+      function(a, b) {
+          declare(type(a = logical(1)), type(b = logical(1)))
+          a / b
+        }
+      <environment: 0x0>
+    Code
+      cat(fsub)
+    Output
+      subroutine fn(a, b, out_) bind(c)
+        use iso_c_binding, only: c_double, c_int
+        implicit none
+      
+        ! manifest start
+        ! args
+        integer(c_int), intent(in) :: a ! logical
+        integer(c_int), intent(in) :: b ! logical
+        real(c_double), intent(out) :: out_
+        ! manifest end
+      
+      
+        out_ = (merge(1.0_c_double, 0.0_c_double, (a/=0)) / merge(1.0_c_double, 0.0_c_double, (b/=0)))
+      end subroutine
+    Code
+      cat(cwrapper)
+    Output
+      #define R_NO_REMAP
+      #include <R.h>
+      #include <Rinternals.h>
+      
+      
+      extern void fn(
+        const int* const a__, 
+        const int* const b__, 
+        double* const out___);
+      
+      SEXP fn_(SEXP _args) {
+        // a
+        _args = CDR(_args);
+        SEXP a = CAR(_args);
+        if (TYPEOF(a) != LGLSXP) {
+          Rf_error("typeof(a) must be 'logical', not '%s'", Rf_type2char(TYPEOF(a)));
+        }
+        const int* const a__ = LOGICAL(a);
+        const R_xlen_t a__len_ = Rf_xlength(a);
+        
+        // b
+        _args = CDR(_args);
+        SEXP b = CAR(_args);
+        if (TYPEOF(b) != LGLSXP) {
+          Rf_error("typeof(b) must be 'logical', not '%s'", Rf_type2char(TYPEOF(b)));
+        }
+        const int* const b__ = LOGICAL(b);
+        const R_xlen_t b__len_ = Rf_xlength(b);
+        
+        if (a__len_ != 1)
+          Rf_error("length(a) must be 1, not %0.f",
+                    (double)a__len_);
+        if (b__len_ != 1)
+          Rf_error("length(b) must be 1, not %0.f",
+                    (double)b__len_);
+        const R_xlen_t out___len_ = (1);
+        SEXP out_ = PROTECT(Rf_allocVector(REALSXP, out___len_));
+        double* out___ = REAL(out_);
+        
+        fn(a__, b__, out___);
         
         UNPROTECT(1);
         return out_;

--- a/tests/testthat/_snaps/div-mod.md
+++ b/tests/testthat/_snaps/div-mod.md
@@ -160,3 +160,78 @@
         return out_;
       }
 
+# integer %/% is exact beyond 2^24
+
+    Code
+      fn
+    Output
+      function(a, b) {
+          declare(type(a = integer(1)), type(b = integer(1)))
+          a %/% b
+        }
+      <environment: 0x0>
+    Code
+      cat(fsub)
+    Output
+      subroutine fn(a, b, out_) bind(c)
+        use iso_c_binding, only: c_double, c_int
+        implicit none
+      
+        ! manifest start
+        ! args
+        integer(c_int), intent(in) :: a
+        integer(c_int), intent(in) :: b
+        integer(c_int), intent(out) :: out_
+        ! manifest end
+      
+      
+        out_ = int(floor(real(a, kind=c_double) / real(b, kind=c_double)), kind=c_int)
+      end subroutine
+    Code
+      cat(cwrapper)
+    Output
+      #define R_NO_REMAP
+      #include <R.h>
+      #include <Rinternals.h>
+      
+      
+      extern void fn(
+        const int* const a__, 
+        const int* const b__, 
+        int* const out___);
+      
+      SEXP fn_(SEXP _args) {
+        // a
+        _args = CDR(_args);
+        SEXP a = CAR(_args);
+        if (TYPEOF(a) != INTSXP) {
+          Rf_error("typeof(a) must be 'integer', not '%s'", Rf_type2char(TYPEOF(a)));
+        }
+        const int* const a__ = INTEGER(a);
+        const R_xlen_t a__len_ = Rf_xlength(a);
+        
+        // b
+        _args = CDR(_args);
+        SEXP b = CAR(_args);
+        if (TYPEOF(b) != INTSXP) {
+          Rf_error("typeof(b) must be 'integer', not '%s'", Rf_type2char(TYPEOF(b)));
+        }
+        const int* const b__ = INTEGER(b);
+        const R_xlen_t b__len_ = Rf_xlength(b);
+        
+        if (a__len_ != 1)
+          Rf_error("length(a) must be 1, not %0.f",
+                    (double)a__len_);
+        if (b__len_ != 1)
+          Rf_error("length(b) must be 1, not %0.f",
+                    (double)b__len_);
+        const R_xlen_t out___len_ = (1);
+        SEXP out_ = PROTECT(Rf_allocVector(INTSXP, out___len_));
+        int* out___ = INTEGER(out_);
+        
+        fn(a__, b__, out___);
+        
+        UNPROTECT(1);
+        return out_;
+      }
+

--- a/tests/testthat/_snaps/unary-intrinsics.md
+++ b/tests/testthat/_snaps/unary-intrinsics.md
@@ -1691,7 +1691,7 @@
         ! manifest end
       
       
-        out = real(z)
+        out = real(z, kind=c_double)
       end subroutine
     Code
       cat(cwrapper)
@@ -1977,6 +1977,69 @@
         Rcomplex* out__ = COMPLEX(out);
         
         fn(z__, out__, z__len_);
+        
+        UNPROTECT(1);
+        return out;
+      }
+
+# Re() on a double argument keeps double precision
+
+    Code
+      fn
+    Output
+      function(x) {
+          declare(type(x = double(n)))
+          out <- Re(x)
+          out
+        }
+      <environment: 0x0>
+    Code
+      cat(fsub)
+    Output
+      subroutine fn(x, out, x__len_) bind(c)
+        use iso_c_binding, only: c_double, c_ptrdiff_t
+        implicit none
+      
+        ! manifest start
+        ! sizes
+        integer(c_ptrdiff_t), intent(in), value :: x__len_
+      
+        ! args
+        real(c_double), intent(in) :: x(x__len_)
+        real(c_double), intent(out) :: out(x__len_)
+        ! manifest end
+      
+      
+        out = real(x, kind=c_double)
+      end subroutine
+    Code
+      cat(cwrapper)
+    Output
+      #define R_NO_REMAP
+      #include <R.h>
+      #include <Rinternals.h>
+      
+      
+      extern void fn(
+        const double* const x__, 
+        double* const out__, 
+        const R_xlen_t x__len_);
+      
+      SEXP fn_(SEXP _args) {
+        // x
+        _args = CDR(_args);
+        SEXP x = CAR(_args);
+        if (TYPEOF(x) != REALSXP) {
+          Rf_error("typeof(x) must be 'double', not '%s'", Rf_type2char(TYPEOF(x)));
+        }
+        const double* const x__ = REAL(x);
+        const R_xlen_t x__len_ = Rf_xlength(x);
+        
+        const R_xlen_t out__len_ = x__len_;
+        SEXP out = PROTECT(Rf_allocVector(REALSXP, out__len_));
+        double* out__ = REAL(out);
+        
+        fn(x__, out__, x__len_);
         
         UNPROTECT(1);
         return out;

--- a/tests/testthat/test-div-cast.R
+++ b/tests/testthat/test-div-cast.R
@@ -42,6 +42,27 @@ test_that("division casts logical", {
 })
 
 
+test_that("division casts logical by logical", {
+  div_lgl_lgl <- function(a, b) {
+    declare(type(a = logical(1)), type(b = logical(1)))
+    a / b
+  }
+
+  # locks the 1.0_c_double/0.0_c_double literals: with integer-kind
+  # 1_c_double literals this was an integer division, and TRUE/FALSE
+  # divided by zero instead of yielding Inf
+  expect_translation_snapshots(div_lgl_lgl)
+
+  expect_quick_equal(
+    div_lgl_lgl,
+    list(TRUE, TRUE),
+    list(TRUE, FALSE), # Inf
+    list(FALSE, TRUE),
+    list(FALSE, FALSE) # NaN
+  )
+})
+
+
 test_that("division casts complex", {
   div_cplx <- function(a, b) {
     declare(type(a = complex(n)), type(b = complex(n)))

--- a/tests/testthat/test-div-mod.R
+++ b/tests/testthat/test-div-mod.R
@@ -36,3 +36,22 @@ test_that("%% and %/%", {
   }
   expect_quick_identical(div_int, x)
 })
+
+test_that("integer %/% is exact beyond 2^24", {
+  div_int_big <- function(a, b) {
+    declare(type(a = integer(1)), type(b = integer(1)))
+    a %/% b
+  }
+
+  # locks the kind=c_double casts: kind-less real() is single precision,
+  # which cannot represent odd integers above 2^24, so e.g.
+  # 16777219L %/% 2L came back as 8388610 instead of 8388609
+  expect_translation_snapshots(div_int_big)
+
+  expect_quick_identical(
+    div_int_big,
+    list(16777219L, 2L),
+    list(-16777219L, 2L),
+    list(.Machine$integer.max, 7L)
+  )
+})

--- a/tests/testthat/test-unary-intrinsics.R
+++ b/tests/testthat/test-unary-intrinsics.R
@@ -106,6 +106,21 @@ test_that("complex unary intrinsics", {
 })
 
 
+test_that("Re() on a double argument keeps double precision", {
+  fn <- function(x) {
+    declare(type(x = double(n)))
+    out <- Re(x)
+    out
+  }
+
+  # locks real(x, kind=c_double): kind-less real() of a double argument
+  # is single precision, so Re() silently rounded its input
+  expect_translation_snapshots(fn)
+
+  expect_quick_identical(fn, list(c(0.1, 1 / 3, -2.5)))
+})
+
+
 test_that("unary logical 'not'-operator on vector", {
   fn <- function(x) {
     declare(type(x = integer(n)))


### PR DESCRIPTION
> **Stacked PR 2 of 15** — branch `conformability/02-literal-kinds`, cut
> from PR 1 (#137), branch `conformability/01-side-effects-and-crashes`.
> GitHub can only diff a fork branch against `main`, so until PR 1 merges
> this page also shows PRs 1–1's commits; the 3 commits new to *this*
> PR are `Emit real literals in the logical-to-double cast` … `Emit Re()
> with an explicit c_double kind`.
>
> Stack overview and suggested review order: #152.

Fixes #123.

## What changed

Three one-line kind/literal corrections in the generated Fortran, each a
silent-wrong-answer fix:

1. **Dividing logicals now yields `Inf`/`NaN` like R instead of undefined
   behavior.** The logical→double cast wrote
   `merge(1_c_double, 0_c_double, x)` — but `1_c_double` is an *integer*
   literal with kind 8, so the division was an integer division and
   `TRUE / FALSE` divided by zero (observed result `1` under gfortran -O2;
   other toolchains trap). It now writes
   `merge(1.0_c_double, 0.0_c_double, x)`:

   ```r
   quick(\(a, b) { declare(type(a = logical(1)), type(b = logical(1))); a / b })(TRUE, FALSE)
   #> before: 1        after: Inf   (R: Inf)
   ```

   This cast helper is shared, so `as.double(<logical>)`, `trunc(<logical>)`,
   and the logical operands of BLAS paths get the same correction for free.

2. **Integer `%/%` is now exact over the full `c_int` range.** The integer
   branch emitted `int(floor(real(a) / real(b)))`; kind-less `real()` is
   single precision, which cannot represent odd integers above 2^24:

   ```r
   quick(\(a, b) { declare(type(a = integer(1)), type(b = integer(1))); a %/% b })(16777219L, 2L)
   #> before: 8388610        after: 8388609   (R: 8388609)
   ```

   Now `int(floor(real(a, kind=c_double) / real(b, kind=c_double)), kind=c_int)`.

3. **`Re()` on a double (or integer) argument no longer rounds through single
   precision.** `Re()` emitted kind-less `real(x)`, which for a non-complex
   `x` is single precision, declared double:

   ```r
   quick(\(x) { declare(type(x = double(1))); Re(x) })(0.1)
   #> before: 0.100000001490116        after: 0.1   (R: 0.1)
   ```

   Now `real(x, kind=c_double)`. For complex arguments this is a no-op change
   of meaning (F2018: kind-less `real(z)` already takes `z`'s kind), so the
   existing complex behavior is unchanged.

## How

One spelling fix at each site — no new helpers, no behavior change beyond the
corrected numeric type:

- `R/r2f-operators-helpers.R`: `maybe_cast_double()` logical branch literals.
- `R/r2f-arithmetic.R`: `%/%` integer branch casts.
- `R/r2f-math.R`: `Re()` intrinsic registration (with a comment on why the
  kind is required).

## Tests

- `test-div-cast.R`: `logical(1) / logical(1)` over all four value pairs
  (`Inf` and `NaN` cases included), plus a translation snapshot locking the
  `1.0_c_double`/`0.0_c_double` literals.
- `test-div-mod.R`: `%/%` at `±16777219L %/% 2L` (odd, > 2^24) and
  `.Machine$integer.max %/% 7L`, plus a snapshot locking the `kind=c_double`
  casts.
- `test-unary-intrinsics.R`: `Re()` on a double vector compared with
  `expect_quick_identical` (bitwise), plus a snapshot locking
  `real(x, kind=c_double)`.

Snapshot churn outside the new tests is exactly two lines, both intended:
`merge(1_c_double, 0_c_double, ...)` → `merge(1.0_c_double, 0.0_c_double, ...)`
in `_snaps/div-cast.md`, and `real(z)` → `real(z, kind=c_double)` in
`_snaps/unary-intrinsics.md`.

## Notes for review

- Stacked on the previous PR in this series (the floor/ceiling/runif
  enablers); the diff here is just the three one-line fixes and their tests.
- All three changes make quickr agree with R where it previously returned a
  different number (or hit UB); none change any case that was already
  correct. Candidate NEWS entry: "Fixed silent precision/correctness bugs in
  logical division, integer `%/%` on values above 2^24, and `Re()` on
  non-complex arguments."
- `Im()`, `Mod()`, `Arg()`, `Conj()` were audited: their spellings are
  correct for complex arguments. For non-complex arguments, `Im()`, `Arg()`,
  and `Conj()` fail loudly at the Fortran stage (`aimag`/`conjg` reject
  reals), and `Mod()` maps to `abs()`, which is already the right answer for
  reals — so all four are left alone.
- The broader issue that operand *modes* are misreported by `conform()` (so
  e.g. mixed int/double arithmetic declares the wrong result mode) is not
  addressed here — it is the next PR in this series; this one only makes the
  cast spellings correct so that work builds on sound literals.