### PR TITLE
[3/15] Apply R's type-promotion lattice: promoted result modes, operand casts, and a narrowing-reassignment error

### DIFF
--- a/R/r2f-arithmetic.R
+++ b/R/r2f-arithmetic.R
@@ -114,8 +114,8 @@ r2f_handlers[["%%"]] <- function(args, scope, ...) {
   Fortran(glue("modulo({left}, {right})"), out_val)
 }
 
-r2f_handlers[["%/%"]] <- function(args, scope, ...) {
-  .[left, right] <- lapply(args, r2f, scope, ...)
+r2f_handlers[["%/%"]] <- function(args, scope, ..., hoist = NULL) {
+  .[left, right] <- lapply(args, r2f, scope, ..., hoist = hoist)
   pair <- promote_arith_pair(left, right, "%/%")
   left <- pair$left
   right <- pair$right
@@ -126,7 +126,18 @@ r2f_handlers[["%/%"]] <- function(args, scope, ...) {
     integer = glue(
       "int(floor(real({left}, kind=c_double) / real({right}, kind=c_double)), kind=c_int)"
     ),
-    double = glue("floor({left} / {right})"),
+    double = {
+      # Fortran FLOOR() returns an integer, so a large double quotient
+      # (e.g. 1e20 %/% 3) would silently overflow. Stay in the real domain
+      # as the floor() handler does; the quotient is spliced three times,
+      # so hoist it to evaluate once.
+      q <- hoist_unless_name(
+        Fortran(glue("({left} / {right})"), out_val),
+        hoist
+      )
+      aint <- glue("aint({q})")
+      glue("({aint} - merge(1.0_c_double, 0.0_c_double, ({q} < {aint})))")
+    },
     stop("%/% only implemented for numeric types")
   )
 

--- a/R/r2f-arithmetic.R
+++ b/R/r2f-arithmetic.R
@@ -7,9 +7,14 @@ r2f_handlers[["+"]] <- function(args, scope, ...) {
   # Support both binary and unary plus
   if (length(args) == 1L) {
     x <- r2f(args[[1L]], scope, ...)
+    # R: +TRUE is 1L
+    x <- cast_to_mode(x, unary_arith_mode(x), "unary +")
     Fortran(glue("(+{x})"), Variable(x@value@mode, x@value@dims))
   } else {
     .[left, right] <- lapply(args, r2f, scope, ...)
+    pair <- promote_arith_pair(left, right, "+")
+    left <- pair$left
+    right <- pair$right
     reshaped <- maybe_reshape_vector_matrix(left, right)
     left <- reshaped$left
     right <- reshaped$right
@@ -21,9 +26,14 @@ r2f_handlers[["-"]] <- function(args, scope, ...) {
   # Support both binary and unary minus
   if (length(args) == 1L) {
     x <- r2f(args[[1L]], scope, ...)
+    # R: -TRUE is -1L
+    x <- cast_to_mode(x, unary_arith_mode(x), "unary -")
     Fortran(glue("(-{x})"), Variable(x@value@mode, x@value@dims))
   } else {
     .[left, right] <- lapply(args, r2f, scope, ...)
+    pair <- promote_arith_pair(left, right, "-")
+    left <- pair$left
+    right <- pair$right
     reshaped <- maybe_reshape_vector_matrix(left, right)
     left <- reshaped$left
     right <- reshaped$right
@@ -33,6 +43,9 @@ r2f_handlers[["-"]] <- function(args, scope, ...) {
 
 r2f_handlers[["*"]] <- function(args, scope = NULL, ...) {
   .[left, right] <- lapply(args, r2f, scope, ...)
+  pair <- promote_arith_pair(left, right, "*")
+  left <- pair$left
+  right <- pair$right
   reshaped <- maybe_reshape_vector_matrix(left, right)
   left <- reshaped$left
   right <- reshaped$right
@@ -51,10 +64,26 @@ r2f_handlers[["/"]] <- function(args, scope = NULL, ...) {
 
 r2f_handlers[["^"]] <- function(args, scope, ...) {
   .[left, right] <- lapply(args, r2f, scope, ...)
+  # R's ^ always returns double (R_pow), so cast the base. Keep an integer
+  # exponent as integer: Fortran `real ** int` is exact and, unlike
+  # `real ** real`, defined for negative bases -- matching R, which
+  # special-cases whole-number exponents.
+  left <- maybe_cast_double(left)
+  if (identical(right@value@mode, "logical")) {
+    right <- cast_to_mode(right, "integer", "^")
+  }
   reshaped <- maybe_reshape_vector_matrix(left, right)
   left <- reshaped$left
   right <- reshaped$right
-  Fortran(glue("({left} ** {right})"), conform(left@value, right@value))
+  mode <- reduce_promoted_mode(left, right)
+  if (!identical(mode, "complex")) {
+    mode <- "double"
+  }
+  # Parenthesizing the exponent avoids non-standard `** -1_c_int`.
+  Fortran(
+    glue("({left} ** ({right}))"),
+    conform(left@value, right@value, mode = mode)
+  )
 }
 
 
@@ -72,6 +101,14 @@ r2f_handlers[["^"]] <- function(args, scope, ...) {
 
 r2f_handlers[["%%"]] <- function(args, scope, ...) {
   .[left, right] <- lapply(args, r2f, scope, ...)
+  # `modulo` requires same-typed arguments, so cast both operands to the
+  # join (logical joins as integer: R's TRUE %% TRUE is 0L).
+  mode <- reduce_promoted_mode(left, right)
+  if (identical(mode, "logical")) {
+    mode <- "integer"
+  }
+  left <- cast_to_mode(left, mode, "%%")
+  right <- cast_to_mode(right, mode, "%%")
   out_val <- conform(left@value, right@value)
   # MODULO gives result with sign(right) - matches R %% behaviour
   Fortran(glue("modulo({left}, {right})"), out_val)
@@ -79,6 +116,9 @@ r2f_handlers[["%%"]] <- function(args, scope, ...) {
 
 r2f_handlers[["%/%"]] <- function(args, scope, ...) {
   .[left, right] <- lapply(args, r2f, scope, ...)
+  pair <- promote_arith_pair(left, right, "%/%")
+  left <- pair$left
+  right <- pair$right
   out_val <- conform(left@value, right@value)
 
   expr <- switch(

--- a/R/r2f-arithmetic.R
+++ b/R/r2f-arithmetic.R
@@ -8,7 +8,7 @@ r2f_handlers[["+"]] <- function(args, scope, ...) {
   if (length(args) == 1L) {
     x <- r2f(args[[1L]], scope, ...)
     # R: +TRUE is 1L
-    x <- cast_to_mode(x, unary_arith_mode(x), "unary +")
+    x <- cast_to_mode(x, arith_join_mode(x), "unary +")
     Fortran(glue("(+{x})"), Variable(x@value@mode, x@value@dims))
   } else {
     .[left, right] <- lapply(args, r2f, scope, ...)
@@ -27,7 +27,7 @@ r2f_handlers[["-"]] <- function(args, scope, ...) {
   if (length(args) == 1L) {
     x <- r2f(args[[1L]], scope, ...)
     # R: -TRUE is -1L
-    x <- cast_to_mode(x, unary_arith_mode(x), "unary -")
+    x <- cast_to_mode(x, arith_join_mode(x), "unary -")
     Fortran(glue("(-{x})"), Variable(x@value@mode, x@value@dims))
   } else {
     .[left, right] <- lapply(args, r2f, scope, ...)
@@ -103,10 +103,7 @@ r2f_handlers[["%%"]] <- function(args, scope, ...) {
   .[left, right] <- lapply(args, r2f, scope, ...)
   # `modulo` requires same-typed arguments, so cast both operands to the
   # join (logical joins as integer: R's TRUE %% TRUE is 0L).
-  mode <- reduce_promoted_mode(left, right)
-  if (identical(mode, "logical")) {
-    mode <- "integer"
-  }
+  mode <- arith_join_mode(left, right)
   left <- cast_to_mode(left, mode, "%%")
   right <- cast_to_mode(right, mode, "%%")
   out_val <- conform(left@value, right@value)

--- a/R/r2f-arithmetic.R
+++ b/R/r2f-arithmetic.R
@@ -12,12 +12,8 @@ r2f_handlers[["+"]] <- function(args, scope, ...) {
     Fortran(glue("(+{x})"), Variable(x@value@mode, x@value@dims))
   } else {
     .[left, right] <- lapply(args, r2f, scope, ...)
-    pair <- promote_arith_pair(left, right, "+")
-    left <- pair$left
-    right <- pair$right
-    reshaped <- maybe_reshape_vector_matrix(left, right)
-    left <- reshaped$left
-    right <- reshaped$right
+    .[left, right] <- promote_arith_pair(left, right, "+")
+    .[left, right] <- maybe_reshape_vector_matrix(left, right)
     Fortran(glue("({left} + {right})"), conform(left@value, right@value))
   }
 }
@@ -31,24 +27,16 @@ r2f_handlers[["-"]] <- function(args, scope, ...) {
     Fortran(glue("(-{x})"), Variable(x@value@mode, x@value@dims))
   } else {
     .[left, right] <- lapply(args, r2f, scope, ...)
-    pair <- promote_arith_pair(left, right, "-")
-    left <- pair$left
-    right <- pair$right
-    reshaped <- maybe_reshape_vector_matrix(left, right)
-    left <- reshaped$left
-    right <- reshaped$right
+    .[left, right] <- promote_arith_pair(left, right, "-")
+    .[left, right] <- maybe_reshape_vector_matrix(left, right)
     Fortran(glue("({left} - {right})"), conform(left@value, right@value))
   }
 }
 
 r2f_handlers[["*"]] <- function(args, scope = NULL, ...) {
   .[left, right] <- lapply(args, r2f, scope, ...)
-  pair <- promote_arith_pair(left, right, "*")
-  left <- pair$left
-  right <- pair$right
-  reshaped <- maybe_reshape_vector_matrix(left, right)
-  left <- reshaped$left
-  right <- reshaped$right
+  .[left, right] <- promote_arith_pair(left, right, "*")
+  .[left, right] <- maybe_reshape_vector_matrix(left, right)
   Fortran(glue("({left} * {right})"), conform(left@value, right@value))
 }
 
@@ -56,9 +44,7 @@ r2f_handlers[["/"]] <- function(args, scope = NULL, ...) {
   .[left, right] <- lapply(args, r2f, scope, ...)
   left <- maybe_cast_double(left)
   right <- maybe_cast_double(right)
-  reshaped <- maybe_reshape_vector_matrix(left, right)
-  left <- reshaped$left
-  right <- reshaped$right
+  .[left, right] <- maybe_reshape_vector_matrix(left, right)
   Fortran(glue("({left} / {right})"), conform(left@value, right@value))
 }
 
@@ -72,9 +58,7 @@ r2f_handlers[["^"]] <- function(args, scope, ...) {
   if (identical(right@value@mode, "logical")) {
     right <- cast_to_mode(right, "integer", "^")
   }
-  reshaped <- maybe_reshape_vector_matrix(left, right)
-  left <- reshaped$left
-  right <- reshaped$right
+  .[left, right] <- maybe_reshape_vector_matrix(left, right)
   mode <- reduce_promoted_mode(left, right)
   if (!identical(mode, "complex")) {
     mode <- "double"
@@ -113,9 +97,7 @@ r2f_handlers[["%%"]] <- function(args, scope, ...) {
 
 r2f_handlers[["%/%"]] <- function(args, scope, ..., hoist = NULL) {
   .[left, right] <- lapply(args, r2f, scope, ..., hoist = hoist)
-  pair <- promote_arith_pair(left, right, "%/%")
-  left <- pair$left
-  right <- pair$right
+  .[left, right] <- promote_arith_pair(left, right, "%/%")
   out_val <- conform(left@value, right@value)
 
   expr <- switch(

--- a/R/r2f-assign.R
+++ b/R/r2f-assign.R
@@ -260,6 +260,12 @@ register_r2f_handler(
     lhs <- compile_subscript_lhs(target_call, scope, ..., target = "local")
     value <- r2f(args[[2L]], scope, ...)
 
+    # Subassignment cannot re-type the base variable any more than
+    # whole-variable reassignment can: `x[1L] <- 2.5` on an integer `x`
+    # would silently truncate where R promotes `x` to double.
+    base_name <- as.character(target_call[[2L]])
+    check_reassignment_narrowing(base_name, get0(base_name, scope), value@value)
+
     Fortran(str_flatten_lines(lhs$pre, glue("{lhs$lhs} = {value}")))
   }
 )
@@ -314,6 +320,7 @@ register_r2f_handler(
     host_scope[[name]] <- host_var
 
     value <- r2f(args[[2L]], scope, ..., hoist = hoist)
+    check_reassignment_narrowing(name, host_var, value@value)
     check_assignment_compatible(host_var, value@value)
 
     Fortran(glue("{host_var@name} = {value}"))
@@ -367,6 +374,7 @@ register_r2f_handler(
       target = "host"
     )
     value <- r2f(args[[2L]], scope, ..., hoist = hoist)
+    check_reassignment_narrowing(name, host_var, value@value)
     Fortran(glue("{lhs$lhs} = {value}"))
   }
 )

--- a/R/r2f-assign.R
+++ b/R/r2f-assign.R
@@ -222,6 +222,7 @@ register_r2f_handler(
         var@mode <- value@value@mode
         var@dims <- value@value@dims
       }
+      check_reassignment_narrowing(name, var, value@value)
       check_assignment_compatible(var, value@value)
       var@modified <- TRUE
       # could probably drop this @modified property, and instead track

--- a/R/r2f-constructors.R
+++ b/R/r2f-constructors.R
@@ -6,6 +6,12 @@
 
 r2f_handlers[["c"]] <- function(args, scope = NULL, ...) {
   ff <- lapply(args, r2f, scope, ...)
+  # Fortran array constructors require uniform element types; cast every
+  # element whose mode differs from the promoted mode (R: c(1L, 2.5) is
+  # double, c(TRUE, 2L) is integer).
+  promoted <- promote_operands(ff, context = "c()")
+  ff <- promoted$args
+  mode <- promoted$mode
   s <- glue("[ {str_flatten_commas(ff)} ]")
   lens <- lapply(ff[order(map_int(ff, \(f) f@value@rank))], function(e) {
     rank <- e@value@rank
@@ -17,7 +23,6 @@ r2f_handlers[["c"]] <- function(args, scope = NULL, ...) {
       stop("all args passed to c() must be scalars or 1-d arrays")
     }
   })
-  mode <- reduce_promoted_mode(ff)
   len <- Reduce(
     \(l1, l2) {
       if (is_scalar_na(l1) || is_scalar_na(l2)) {

--- a/R/r2f-logical.R
+++ b/R/r2f-logical.R
@@ -8,9 +8,7 @@
 r2f_handlers[[">="]] <- function(args, scope, ...) {
   .[left, right] <- lapply(args, r2f, scope, ...)
   # R compares logicals as integers; Fortran has no logical comparison.
-  pair <- promote_arith_pair(left, right, "comparison")
-  left <- pair$left
-  right <- pair$right
+  .[left, right] <- promote_arith_pair(left, right, "comparison")
   var <- conform(left@value, right@value)
   var@mode <- "logical"
   Fortran(glue("({left} >= {right})"), var)
@@ -19,9 +17,7 @@ r2f_handlers[[">="]] <- function(args, scope, ...) {
 r2f_handlers[[">"]] <- function(args, scope, ...) {
   .[left, right] <- lapply(args, r2f, scope, ...)
   # R compares logicals as integers; Fortran has no logical comparison.
-  pair <- promote_arith_pair(left, right, "comparison")
-  left <- pair$left
-  right <- pair$right
+  .[left, right] <- promote_arith_pair(left, right, "comparison")
   var <- conform(left@value, right@value)
   var@mode <- "logical"
   Fortran(glue("({left} > {right})"), var)
@@ -30,9 +26,7 @@ r2f_handlers[[">"]] <- function(args, scope, ...) {
 r2f_handlers[["<"]] <- function(args, scope, ...) {
   .[left, right] <- lapply(args, r2f, scope, ...)
   # R compares logicals as integers; Fortran has no logical comparison.
-  pair <- promote_arith_pair(left, right, "comparison")
-  left <- pair$left
-  right <- pair$right
+  .[left, right] <- promote_arith_pair(left, right, "comparison")
   var <- conform(left@value, right@value)
   var@mode <- "logical"
   Fortran(glue("({left} < {right})"), var)
@@ -41,9 +35,7 @@ r2f_handlers[["<"]] <- function(args, scope, ...) {
 r2f_handlers[["<="]] <- function(args, scope, ...) {
   .[left, right] <- lapply(args, r2f, scope, ...)
   # R compares logicals as integers; Fortran has no logical comparison.
-  pair <- promote_arith_pair(left, right, "comparison")
-  left <- pair$left
-  right <- pair$right
+  .[left, right] <- promote_arith_pair(left, right, "comparison")
   var <- conform(left@value, right@value)
   var@mode <- "logical"
   Fortran(glue("({left} <= {right})"), var)
@@ -52,9 +44,7 @@ r2f_handlers[["<="]] <- function(args, scope, ...) {
 r2f_handlers[["=="]] <- function(args, scope, ...) {
   .[left, right] <- lapply(args, r2f, scope, ...)
   # R compares logicals as integers; Fortran has no logical comparison.
-  pair <- promote_arith_pair(left, right, "comparison")
-  left <- pair$left
-  right <- pair$right
+  .[left, right] <- promote_arith_pair(left, right, "comparison")
   var <- conform(left@value, right@value)
   var@mode <- "logical"
   Fortran(glue("({left} == {right})"), var)
@@ -63,9 +53,7 @@ r2f_handlers[["=="]] <- function(args, scope, ...) {
 r2f_handlers[["!="]] <- function(args, scope, ...) {
   .[left, right] <- lapply(args, r2f, scope, ...)
   # R compares logicals as integers; Fortran has no logical comparison.
-  pair <- promote_arith_pair(left, right, "comparison")
-  left <- pair$left
-  right <- pair$right
+  .[left, right] <- promote_arith_pair(left, right, "comparison")
   var <- conform(left@value, right@value)
   var@mode <- "logical"
   Fortran(glue("({left} /= {right})"), var)

--- a/R/r2f-logical.R
+++ b/R/r2f-logical.R
@@ -7,6 +7,10 @@
 
 r2f_handlers[[">="]] <- function(args, scope, ...) {
   .[left, right] <- lapply(args, r2f, scope, ...)
+  # R compares logicals as integers; Fortran has no logical comparison.
+  pair <- promote_arith_pair(left, right, "comparison")
+  left <- pair$left
+  right <- pair$right
   var <- conform(left@value, right@value)
   var@mode <- "logical"
   Fortran(glue("({left} >= {right})"), var)
@@ -14,6 +18,10 @@ r2f_handlers[[">="]] <- function(args, scope, ...) {
 
 r2f_handlers[[">"]] <- function(args, scope, ...) {
   .[left, right] <- lapply(args, r2f, scope, ...)
+  # R compares logicals as integers; Fortran has no logical comparison.
+  pair <- promote_arith_pair(left, right, "comparison")
+  left <- pair$left
+  right <- pair$right
   var <- conform(left@value, right@value)
   var@mode <- "logical"
   Fortran(glue("({left} > {right})"), var)
@@ -21,6 +29,10 @@ r2f_handlers[[">"]] <- function(args, scope, ...) {
 
 r2f_handlers[["<"]] <- function(args, scope, ...) {
   .[left, right] <- lapply(args, r2f, scope, ...)
+  # R compares logicals as integers; Fortran has no logical comparison.
+  pair <- promote_arith_pair(left, right, "comparison")
+  left <- pair$left
+  right <- pair$right
   var <- conform(left@value, right@value)
   var@mode <- "logical"
   Fortran(glue("({left} < {right})"), var)
@@ -28,6 +40,10 @@ r2f_handlers[["<"]] <- function(args, scope, ...) {
 
 r2f_handlers[["<="]] <- function(args, scope, ...) {
   .[left, right] <- lapply(args, r2f, scope, ...)
+  # R compares logicals as integers; Fortran has no logical comparison.
+  pair <- promote_arith_pair(left, right, "comparison")
+  left <- pair$left
+  right <- pair$right
   var <- conform(left@value, right@value)
   var@mode <- "logical"
   Fortran(glue("({left} <= {right})"), var)
@@ -35,6 +51,10 @@ r2f_handlers[["<="]] <- function(args, scope, ...) {
 
 r2f_handlers[["=="]] <- function(args, scope, ...) {
   .[left, right] <- lapply(args, r2f, scope, ...)
+  # R compares logicals as integers; Fortran has no logical comparison.
+  pair <- promote_arith_pair(left, right, "comparison")
+  left <- pair$left
+  right <- pair$right
   var <- conform(left@value, right@value)
   var@mode <- "logical"
   Fortran(glue("({left} == {right})"), var)
@@ -42,6 +62,10 @@ r2f_handlers[["=="]] <- function(args, scope, ...) {
 
 r2f_handlers[["!="]] <- function(args, scope, ...) {
   .[left, right] <- lapply(args, r2f, scope, ...)
+  # R compares logicals as integers; Fortran has no logical comparison.
+  pair <- promote_arith_pair(left, right, "comparison")
+  left <- pair$left
+  right <- pair$right
   var <- conform(left@value, right@value)
   var@mode <- "logical"
   Fortran(glue("({left} /= {right})"), var)

--- a/R/r2f-math.R
+++ b/R/r2f-math.R
@@ -121,6 +121,9 @@ r2f_handlers[["log10"]] <- function(args, scope, ...) {
 r2f_handlers[["abs"]] <- function(args, scope, ...) {
   stopifnot(length(args) == 1L)
   arg <- r2f(args[[1]], scope, ...)
+  # R: abs(logical) is integer (abs(TRUE) is 1L); Fortran's abs() requires
+  # a numeric argument, so a logical operand participates as integer.
+  arg <- cast_to_mode(arg, arith_join_mode(arg), "abs()")
   out_mode <- if (arg@value@mode == "complex") "double" else arg@value@mode
   Fortran(glue("abs({arg})"), Variable(mode = out_mode, dims = arg@value@dims))
 }

--- a/R/r2f-matrix.R
+++ b/R/r2f-matrix.R
@@ -224,29 +224,6 @@ bind_output_mode <- function(values, context) {
   stop(context, " does not support input mode(s): ", str_flatten_commas(modes))
 }
 
-bind_cast_value <- function(value, mode, context) {
-  if (identical(value@value@mode, mode)) {
-    return(value)
-  }
-  if (identical(mode, "double")) {
-    return(maybe_cast_double(value))
-  }
-  if (identical(mode, "integer") && identical(value@value@mode, "logical")) {
-    return(Fortran(
-      glue("merge(1_c_int, 0_c_int, {value})"),
-      Variable("integer", value@value@dims)
-    ))
-  }
-  stop(
-    context,
-    " does not support coercion from ",
-    value@value@mode,
-    " to ",
-    mode,
-    call. = FALSE
-  )
-}
-
 bind_dim_sum <- function(values, context, label) {
   if (!length(values)) {
     return(0L)
@@ -381,7 +358,7 @@ register_r2f_handler(
     }
 
     mode <- bind_output_mode(values, context)
-    values <- lapply(values, bind_cast_value, mode = mode, context = context)
+    values <- lapply(values, cast_to_mode, mode = mode, context = context)
 
     dims <- lapply(values, matrix_dims, orientation = "colvec")
     scalar_flags <- map_lgl(values, \(val) passes_as_scalar(val@value))
@@ -437,7 +414,7 @@ register_r2f_handler(
     }
 
     mode <- bind_output_mode(values, context)
-    values <- lapply(values, bind_cast_value, mode = mode, context = context)
+    values <- lapply(values, cast_to_mode, mode = mode, context = context)
 
     dims <- lapply(values, matrix_dims, orientation = "rowvec")
     scalar_flags <- map_lgl(values, \(val) passes_as_scalar(val@value))

--- a/R/r2f-operators-helpers.R
+++ b/R/r2f-operators-helpers.R
@@ -275,6 +275,17 @@ maybe_reshape_vector_matrix <- function(left, right) {
   list(left = left, right = right)
 }
 
+# R's promotion order for the supported atomic modes, lowest to highest.
+# The one place the lattice is spelled: promotion joins take the highest
+# rank present; the narrowing check refuses assignments that move down.
+mode_lattice <- c("logical", "integer", "double", "complex")
+
+# Rank of a mode on the lattice (NA for modes outside it, e.g. character).
+# Used by: reduce_promoted_mode(), scope.R (check_reassignment_narrowing)
+mode_rank <- function(mode) {
+  match(mode, mode_lattice)
+}
+
 # Determine the promoted mode from a list of Fortran values.
 # Used by: r2f-arithmetic.R, r2f-constructors.R
 reduce_promoted_mode <- function(...) {
@@ -291,16 +302,11 @@ reduce_promoted_mode <- function(...) {
   }
   modes <- unique(unlist(getmode(list(...))))
 
-  if ("complex" %in% modes) {
-    "complex"
-  } else if ("double" %in% modes) {
-    "double"
-  } else if ("integer" %in% modes) {
-    "integer"
-  } else if ("logical" %in% modes) {
-    "logical"
-  } else {
+  ranks <- mode_rank(modes)
+  if (!length(ranks) || all(is.na(ranks))) {
     NULL
+  } else {
+    mode_lattice[[max(ranks, na.rm = TRUE)]]
   }
 }
 

--- a/R/r2f-operators-helpers.R
+++ b/R/r2f-operators-helpers.R
@@ -25,22 +25,102 @@ booleanize_logical_as_int <- function(x) {
   out
 }
 
-# Cast a value to double if it's logical or integer.
-# Used by: r2f-arithmetic.R
-maybe_cast_double <- function(x) {
-  if (x@value@mode == "logical") {
-    Fortran(
-      glue("merge(1.0_c_double, 0.0_c_double, {x})"),
-      Variable("double", x@value@dims)
-    )
-  } else if (x@value@mode == "integer") {
-    Fortran(
+# Cast a Fortran value to a target mode by wrapping its expression text.
+# The only place cast spellings live; errors on casts it cannot spell
+# (complex/character operands, or any narrowing) so an unsupported mode is
+# a clean diagnostic instead of invalid generated Fortran.
+# Used by: r2f-arithmetic.R, r2f-logical.R, r2f-constructors.R,
+#          r2f-reductions.R, r2f-matrix.R
+cast_to_mode <- function(x, mode, context = "operand") {
+  stopifnot(inherits(x, Fortran))
+  if (
+    is.null(mode) ||
+      is.null(x@value@mode) || # mode still being inferred; nothing to spell
+      identical(x@value@mode, mode)
+  ) {
+    return(x)
+  }
+  from <- x@value@mode
+  if (identical(mode, "double") && identical(from, "integer")) {
+    return(Fortran(
       glue("real({x}, kind=c_double)"),
       Variable("double", x@value@dims)
+    ))
+  }
+  if (identical(from, "logical") && mode %in% c("integer", "double")) {
+    if (logical_as_int(x@value) && !isTRUE(x@logical_booleanized)) {
+      # bind(c) logicals are already 0/1 integer storage; relabel, or cast
+      # the integer text directly for a double target.
+      relabeled <- Fortran(glue("{x}"), Variable("integer", x@value@dims))
+      return(cast_to_mode(relabeled, mode, context))
+    }
+    x <- booleanize_logical_as_int(x)
+    literals <- switch(
+      mode,
+      integer = "1_c_int, 0_c_int",
+      double = "1.0_c_double, 0.0_c_double"
     )
+    return(Fortran(
+      glue("merge({literals}, {x})"),
+      Variable(mode, x@value@dims)
+    ))
+  }
+  stop(
+    context,
+    " does not support coercion from ",
+    from,
+    " to ",
+    mode,
+    call. = FALSE
+  )
+}
+
+# Cast a value to double if it's logical or integer.
+# Used by: r2f-arithmetic.R, r2f-math.R, r2f-matrix*.R, r2f-coercions.R
+maybe_cast_double <- function(x) {
+  if (x@value@mode %in% c("logical", "integer")) {
+    cast_to_mode(x, "double")
   } else {
     x
   }
+}
+
+# Promote a list of operands to their common (lattice-join) mode, casting
+# each one whose mode differs. For contexts where Fortran requires uniform
+# argument types: array constructors (c()), min/max, merge, modulo.
+# Returns list(args = <cast operands>, mode = <join>).
+# Used by: r2f-arithmetic.R, r2f-constructors.R, r2f-reductions.R
+promote_operands <- function(args, context = "operator") {
+  mode <- reduce_promoted_mode(args)
+  list(
+    args = lapply(args, cast_to_mode, mode = mode, context = context),
+    mode = mode
+  )
+}
+
+# Arithmetic mode of a single operand: logical participates as integer.
+# Used by: r2f-arithmetic.R (unary + and -)
+unary_arith_mode <- function(x) {
+  if (identical(x@value@mode, "logical")) "integer" else x@value@mode
+}
+
+# Apply R's arithmetic rule for logical operands: they join as integer
+# (TRUE + TRUE is 2L), and Fortran has no logical arithmetic, so cast them.
+# int/double mixes are left alone -- Fortran's own promotion matches R.
+# Used by: r2f-arithmetic.R, r2f-logical.R
+promote_arith_pair <- function(left, right, context = "arithmetic") {
+  if (
+    identical(left@value@mode, "logical") ||
+      identical(right@value@mode, "logical")
+  ) {
+    mode <- reduce_promoted_mode(left, right)
+    if (identical(mode, "logical")) {
+      mode <- "integer"
+    }
+    left <- cast_to_mode(left, mode, context)
+    right <- cast_to_mode(right, mode, context)
+  }
+  list(left = left, right = right)
 }
 
 # Check if a dimension expression equals 1.
@@ -212,7 +292,9 @@ reduce_promoted_mode <- function(...) {
   }
   modes <- unique(unlist(getmode(list(...))))
 
-  if ("double" %in% modes) {
+  if ("complex" %in% modes) {
+    "complex"
+  } else if ("double" %in% modes) {
     "double"
   } else if ("integer" %in% modes) {
     "integer"
@@ -226,9 +308,14 @@ reduce_promoted_mode <- function(...) {
 # Create a Variable with conforming dimensions from multiple inputs.
 # Used by: r2f-arithmetic.R, r2f-logical.R, r2f-constructors.R, r2f-conditionals.R
 conform <- function(..., mode = NULL) {
+  vars <- drop_nulls(list(...))
+  # Report the promoted (lattice-join) mode: the emitted expression already
+  # promotes (Fortran's rules match R for numeric mixes), and `<-` copies
+  # the reported mode verbatim into the target's declaration, so reporting
+  # the first non-scalar's mode declared truncating targets.
+  mode <- mode %||% reduce_promoted_mode(vars)
   var <- NULL
-  # technically, types are implicit promoted, but we'll let <- handle that.
-  for (var in drop_nulls(list(...))) {
+  for (var in vars) {
     if (passes_as_scalar(var)) {
       next
     } else {

--- a/R/r2f-operators-helpers.R
+++ b/R/r2f-operators-helpers.R
@@ -98,10 +98,12 @@ promote_operands <- function(args, context = "operator") {
   )
 }
 
-# Arithmetic mode of a single operand: logical participates as integer.
-# Used by: r2f-arithmetic.R (unary + and -)
-unary_arith_mode <- function(x) {
-  if (identical(x@value@mode, "logical")) "integer" else x@value@mode
+# Lattice join for arithmetic contexts: logical joins as integer (R:
+# TRUE + TRUE is 2L, sum(TRUE) is 1L; Fortran has no logical arithmetic).
+# Used by: r2f-arithmetic.R, r2f-math.R, r2f-reductions.R
+arith_join_mode <- function(...) {
+  mode <- reduce_promoted_mode(...)
+  if (identical(mode, "logical")) "integer" else mode
 }
 
 # Apply R's arithmetic rule for logical operands: they join as integer
@@ -113,10 +115,7 @@ promote_arith_pair <- function(left, right, context = "arithmetic") {
     identical(left@value@mode, "logical") ||
       identical(right@value@mode, "logical")
   ) {
-    mode <- reduce_promoted_mode(left, right)
-    if (identical(mode, "logical")) {
-      mode <- "integer"
-    }
+    mode <- arith_join_mode(left, right)
     left <- cast_to_mode(left, mode, context)
     right <- cast_to_mode(right, mode, context)
   }

--- a/R/r2f-reductions.R
+++ b/R/r2f-reductions.R
@@ -68,7 +68,16 @@ register_r2f_handler(
       reduce_arg(args[[1]])
     } else {
       args <- lapply(args, reduce_arg)
+      # Fortran's max/min require uniform argument types; cast every operand
+      # whose mode differs from the join. The + / * spellings for sum/prod
+      # don't strictly need it, but one code path beats two. Logical
+      # operands join as integer (R: max(TRUE, FALSE) is 1L).
       mode <- reduce_promoted_mode(args)
+      if (identical(mode, "logical")) {
+        mode <- "integer"
+      }
+      context <- sprintf("%s()", last(list(...)$calls))
+      args <- lapply(args, cast_to_mode, mode = mode, context = context)
       s <- switch(
         last(list(...)$calls),
         max = glue("max({str_flatten_commas(args)})"),

--- a/R/r2f-reductions.R
+++ b/R/r2f-reductions.R
@@ -50,6 +50,13 @@ register_r2f_handler(
           call. = FALSE
         )
       }
+      # R's numeric reductions treat logicals as integers (sum(TRUE) is 1L),
+      # and Fortran's sum/product/minval/maxval reject logical arrays.
+      x <- cast_to_mode(
+        x,
+        arith_join_mode(x),
+        sprintf("%s()", last(dots$calls))
+      )
       if (x@value@is_scalar) {
         return(x)
       }
@@ -72,10 +79,7 @@ register_r2f_handler(
       # whose mode differs from the join. The + / * spellings for sum/prod
       # don't strictly need it, but one code path beats two. Logical
       # operands join as integer (R: max(TRUE, FALSE) is 1L).
-      mode <- reduce_promoted_mode(args)
-      if (identical(mode, "logical")) {
-        mode <- "integer"
-      }
+      mode <- arith_join_mode(args)
       context <- sprintf("%s()", last(list(...)$calls))
       args <- lapply(args, cast_to_mode, mode = mode, context = context)
       s <- switch(

--- a/R/scope.R
+++ b/R/scope.R
@@ -69,6 +69,40 @@ check_assignment_compatible <- function(target, value) {
   })
 }
 
+# Reassignment cannot re-type a Fortran variable the way R promotes an R
+# binding, so a value whose mode sits above the variable's on the lattice
+# (logical < integer < double < complex) would be silently truncated by the
+# assignment. Refuse at compile time instead.
+check_reassignment_narrowing <- function(name, target, value) {
+  if (
+    !inherits(target, Variable) ||
+      !inherits(value, Variable) ||
+      is.null(target@mode) ||
+      is.null(value@mode)
+  ) {
+    return()
+  }
+  lattice <- c("logical", "integer", "double", "complex")
+  target_rank <- match(target@mode, lattice)
+  value_rank <- match(value@mode, lattice)
+  if (is.na(target_rank) || is.na(value_rank) || value_rank <= target_rank) {
+    return()
+  }
+  stop(
+    "cannot reassign `",
+    name,
+    "`: assignment would narrow ",
+    value@mode,
+    " to ",
+    target@mode,
+    "; R would promote `",
+    name,
+    "` to ",
+    value@mode,
+    call. = FALSE
+  )
+}
+
 new_scope <- function(closure, parent = emptyenv()) {
   scope <- new_ordered_env(parent = parent)
   class(scope) <- unique(c("quickr_scope", class(scope)))

--- a/R/scope.R
+++ b/R/scope.R
@@ -82,9 +82,8 @@ check_reassignment_narrowing <- function(name, target, value) {
   ) {
     return()
   }
-  lattice <- c("logical", "integer", "double", "complex")
-  target_rank <- match(target@mode, lattice)
-  value_rank <- match(value@mode, lattice)
+  target_rank <- mode_rank(target@mode)
+  value_rank <- mode_rank(value@mode)
   if (is.na(target_rank) || is.na(value_rank) || value_rank <= target_rank) {
     return()
   }

--- a/tests/testthat/_snaps/div-mod.md
+++ b/tests/testthat/_snaps/div-mod.md
@@ -107,7 +107,13 @@
         ! manifest end
       
       
-        out_ = floor(a / b)
+        block
+          real(c_double), allocatable :: btmp1_(:)
+      
+          allocate(btmp1_(a__len_))
+          btmp1_ = (a / b)
+          out_ = (aint(btmp1_) - merge(1.0_c_double, 0.0_c_double, (btmp1_ < aint(btmp1_))))
+        end block
       end subroutine
     Code
       cat(cwrapper)
@@ -228,6 +234,86 @@
         const R_xlen_t out___len_ = (1);
         SEXP out_ = PROTECT(Rf_allocVector(INTSXP, out___len_));
         int* out___ = INTEGER(out_);
+        
+        fn(a__, b__, out___);
+        
+        UNPROTECT(1);
+        return out_;
+      }
+
+# double %/% stays exact beyond integer range
+
+    Code
+      fn
+    Output
+      function(a, b) {
+          declare(type(a = double(1)), type(b = double(1)))
+          a %/% b
+        }
+      <environment: 0x0>
+    Code
+      cat(fsub)
+    Output
+      subroutine fn(a, b, out_) bind(c)
+        use iso_c_binding, only: c_double
+        implicit none
+      
+        ! manifest start
+        ! args
+        real(c_double), intent(in) :: a
+        real(c_double), intent(in) :: b
+        real(c_double), intent(out) :: out_
+        ! manifest end
+      
+      
+        block
+          real(c_double) :: btmp1_
+      
+          btmp1_ = (a / b)
+          out_ = (aint(btmp1_) - merge(1.0_c_double, 0.0_c_double, (btmp1_ < aint(btmp1_))))
+        end block
+      end subroutine
+    Code
+      cat(cwrapper)
+    Output
+      #define R_NO_REMAP
+      #include <R.h>
+      #include <Rinternals.h>
+      
+      
+      extern void fn(
+        const double* const a__, 
+        const double* const b__, 
+        double* const out___);
+      
+      SEXP fn_(SEXP _args) {
+        // a
+        _args = CDR(_args);
+        SEXP a = CAR(_args);
+        if (TYPEOF(a) != REALSXP) {
+          Rf_error("typeof(a) must be 'double', not '%s'", Rf_type2char(TYPEOF(a)));
+        }
+        const double* const a__ = REAL(a);
+        const R_xlen_t a__len_ = Rf_xlength(a);
+        
+        // b
+        _args = CDR(_args);
+        SEXP b = CAR(_args);
+        if (TYPEOF(b) != REALSXP) {
+          Rf_error("typeof(b) must be 'double', not '%s'", Rf_type2char(TYPEOF(b)));
+        }
+        const double* const b__ = REAL(b);
+        const R_xlen_t b__len_ = Rf_xlength(b);
+        
+        if (a__len_ != 1)
+          Rf_error("length(a) must be 1, not %0.f",
+                    (double)a__len_);
+        if (b__len_ != 1)
+          Rf_error("length(b) must be 1, not %0.f",
+                    (double)b__len_);
+        const R_xlen_t out___len_ = (1);
+        SEXP out_ = PROTECT(Rf_allocVector(REALSXP, out___len_));
+        double* out___ = REAL(out_);
         
         fn(a__, b__, out___);
         

--- a/tests/testthat/_snaps/example-heat_diffusion.md
+++ b/tests/testthat/_snaps/example-heat_diffusion.md
@@ -134,8 +134,8 @@
             do i = 2_c_int, ((nx - 1_c_int)), sign(1, ((nx - 1_c_int))-2_c_int)
               do j = 2_c_int, ((ny - 1_c_int)), sign(1, ((ny - 1_c_int))-2_c_int)
       temp_new(i, j) = (temp(i, j) + ((k * dt) * ((((((temp((i + 1_c_int), j) - (2.0_c_double * temp(i, j))) + temp((i - 1_c_int), j)))&
-          & / (dx ** 2.0_c_double)) + ((((temp(i, (j + 1_c_int)) - (2.0_c_double * temp(i, j))) + temp(i, (j - 1_c_int)))) / (dy **&
-          & 2.0_c_double))))))
+          & / (real(dx, kind=c_double) ** (2.0_c_double))) + ((((temp(i, (j + 1_c_int)) - (2.0_c_double * temp(i, j))) + temp(i, (j -&
+          & 1_c_int)))) / (real(dy, kind=c_double) ** (2.0_c_double)))))))
               end do
             end do
             res = temp_new
@@ -390,8 +390,8 @@
             do i = 2_c_int, ((nx - 1_c_int)), sign(1, ((nx - 1_c_int))-2_c_int)
               do j = 2_c_int, ((ny - 1_c_int)), sign(1, ((ny - 1_c_int))-2_c_int)
       temp_new(i, j) = (temp(i, j) + ((k * dt) * ((((((temp((i + 1_c_int), j) - (2.0_c_double * temp(i, j))) + temp((i - 1_c_int), j)))&
-          & / (dx ** 2.0_c_double)) + ((((temp(i, (j + 1_c_int)) - (2.0_c_double * temp(i, j))) + temp(i, (j - 1_c_int)))) / (dy **&
-          & 2.0_c_double))))))
+          & / (real(dx, kind=c_double) ** (2.0_c_double))) + ((((temp(i, (j + 1_c_int)) - (2.0_c_double * temp(i, j))) + temp(i, (j -&
+          & 1_c_int)))) / (real(dy, kind=c_double) ** (2.0_c_double)))))))
               end do
             end do
             res = temp_new

--- a/tests/testthat/_snaps/type-promotion.md
+++ b/tests/testthat/_snaps/type-promotion.md
@@ -405,7 +405,7 @@
     Output
       function(x) {
           declare(type(x = integer(1)))
-          x ^ -1L
+          x^-1L
         }
       <environment: 0x0>
     Code

--- a/tests/testthat/_snaps/type-promotion.md
+++ b/tests/testthat/_snaps/type-promotion.md
@@ -532,3 +532,65 @@
         return out_;
       }
 
+# abs() and single-arg reductions accept logical operands like R
+
+    Code
+      fn
+    Output
+      function(x) {
+          declare(type(x = logical(n)))
+          abs(x)
+        }
+      <environment: 0x0>
+    Code
+      cat(fsub)
+    Output
+      subroutine fn(x, out_, x__len_) bind(c)
+        use iso_c_binding, only: c_int, c_ptrdiff_t
+        implicit none
+      
+        ! manifest start
+        ! sizes
+        integer(c_ptrdiff_t), intent(in), value :: x__len_
+      
+        ! args
+        integer(c_int), intent(in) :: x(x__len_) ! logical
+        integer(c_int), intent(out) :: out_(x__len_)
+        ! manifest end
+      
+      
+        out_ = abs(merge(1_c_int, 0_c_int, (x/=0)))
+      end subroutine
+    Code
+      cat(cwrapper)
+    Output
+      #define R_NO_REMAP
+      #include <R.h>
+      #include <Rinternals.h>
+      
+      
+      extern void fn(
+        const int* const x__, 
+        int* const out___, 
+        const R_xlen_t x__len_);
+      
+      SEXP fn_(SEXP _args) {
+        // x
+        _args = CDR(_args);
+        SEXP x = CAR(_args);
+        if (TYPEOF(x) != LGLSXP) {
+          Rf_error("typeof(x) must be 'logical', not '%s'", Rf_type2char(TYPEOF(x)));
+        }
+        const int* const x__ = LOGICAL(x);
+        const R_xlen_t x__len_ = Rf_xlength(x);
+        
+        const R_xlen_t out___len_ = x__len_;
+        SEXP out_ = PROTECT(Rf_allocVector(INTSXP, out___len_));
+        int* out___ = INTEGER(out_);
+        
+        fn(x__, out___, x__len_);
+        
+        UNPROTECT(1);
+        return out_;
+      }
+

--- a/tests/testthat/_snaps/type-promotion.md
+++ b/tests/testthat/_snaps/type-promotion.md
@@ -594,3 +594,51 @@
         return out_;
       }
 
+# reassignment that would narrow the mode is a compile error
+
+    Code
+      quick(function(x) {
+        declare(type(x = integer(1)))
+        x <- x + 0.5
+        x
+      })
+    Condition
+      Error:
+      ! cannot reassign `x`: assignment would narrow double to integer; R would promote `x` to double
+
+---
+
+    Code
+      quick(function(x) {
+        declare(type(x = logical(1)))
+        x <- x + 1L
+        x
+      })
+    Condition
+      Error:
+      ! cannot reassign `x`: assignment would narrow integer to logical; R would promote `x` to integer
+
+# subassignment that would narrow the mode is a compile error
+
+    Code
+      quick(function(x) {
+        declare(type(x = integer(3)))
+        x[1L] <- 2.5
+        x
+      })
+    Condition
+      Error:
+      ! cannot reassign `x`: assignment would narrow double to integer; R would promote `x` to double
+
+---
+
+    Code
+      quick(function(x) {
+        declare(type(x = integer(n)))
+        x[1:2] <- x[1:2] / 2
+        x
+      })
+    Condition
+      Error:
+      ! cannot reassign `x`: assignment would narrow double to integer; R would promote `x` to double
+

--- a/tests/testthat/_snaps/type-promotion.md
+++ b/tests/testthat/_snaps/type-promotion.md
@@ -1,0 +1,534 @@
+# integer + double promotes to double
+
+    Code
+      fn
+    Output
+      function(x) {
+          declare(type(x = integer(n)))
+          x + 0.5
+        }
+      <environment: 0x0>
+    Code
+      cat(fsub)
+    Output
+      subroutine fn(x, out_, x__len_) bind(c)
+        use iso_c_binding, only: c_double, c_int, c_ptrdiff_t
+        implicit none
+      
+        ! manifest start
+        ! sizes
+        integer(c_ptrdiff_t), intent(in), value :: x__len_
+      
+        ! args
+        integer(c_int), intent(in) :: x(x__len_)
+        real(c_double), intent(out) :: out_(x__len_)
+        ! manifest end
+      
+      
+        out_ = (x + 0.5_c_double)
+      end subroutine
+    Code
+      cat(cwrapper)
+    Output
+      #define R_NO_REMAP
+      #include <R.h>
+      #include <Rinternals.h>
+      
+      
+      extern void fn(
+        const int* const x__, 
+        double* const out___, 
+        const R_xlen_t x__len_);
+      
+      SEXP fn_(SEXP _args) {
+        // x
+        _args = CDR(_args);
+        SEXP x = CAR(_args);
+        if (TYPEOF(x) != INTSXP) {
+          Rf_error("typeof(x) must be 'integer', not '%s'", Rf_type2char(TYPEOF(x)));
+        }
+        const int* const x__ = INTEGER(x);
+        const R_xlen_t x__len_ = Rf_xlength(x);
+        
+        const R_xlen_t out___len_ = x__len_;
+        SEXP out_ = PROTECT(Rf_allocVector(REALSXP, out___len_));
+        double* out___ = REAL(out_);
+        
+        fn(x__, out___, x__len_);
+        
+        UNPROTECT(1);
+        return out_;
+      }
+
+# real-valued RHS with integer operand declares a double binding
+
+    Code
+      fn
+    Output
+      function(x) {
+          declare(type(x = double(1)))
+          out <- x * 3L
+          out
+        }
+      <environment: 0x0>
+    Code
+      cat(fsub)
+    Output
+      subroutine fn(x, out) bind(c)
+        use iso_c_binding, only: c_double, c_int
+        implicit none
+      
+        ! manifest start
+        ! args
+        real(c_double), intent(in) :: x
+        real(c_double), intent(out) :: out
+        ! manifest end
+      
+      
+        out = (x * 3_c_int)
+      end subroutine
+    Code
+      cat(cwrapper)
+    Output
+      #define R_NO_REMAP
+      #include <R.h>
+      #include <Rinternals.h>
+      
+      
+      extern void fn(const double* const x__, double* const out__);
+      
+      SEXP fn_(SEXP _args) {
+        // x
+        _args = CDR(_args);
+        SEXP x = CAR(_args);
+        if (TYPEOF(x) != REALSXP) {
+          Rf_error("typeof(x) must be 'double', not '%s'", Rf_type2char(TYPEOF(x)));
+        }
+        const double* const x__ = REAL(x);
+        const R_xlen_t x__len_ = Rf_xlength(x);
+        
+        if (x__len_ != 1)
+          Rf_error("length(x) must be 1, not %0.f",
+                    (double)x__len_);
+        const R_xlen_t out__len_ = (1);
+        SEXP out = PROTECT(Rf_allocVector(REALSXP, out__len_));
+        double* out__ = REAL(out);
+        
+        fn(x__, out__);
+        
+        UNPROTECT(1);
+        return out;
+      }
+
+# misreported mode does not defeat subscript coercion
+
+    Code
+      fn
+    Output
+      function(x) {
+          declare(type(x = double(NA)))
+          out <- x[as.integer(runif(1) * 3) + 1L]
+          out
+        }
+      <environment: 0x0>
+    Code
+      cat(fsub)
+    Output
+      subroutine fn(x, out, x__len_) bind(c)
+        use iso_c_binding, only: c_double, c_int, c_ptrdiff_t
+        implicit none
+      
+        ! manifest start
+        ! sizes
+        integer(c_ptrdiff_t), intent(in), value :: x__len_
+      
+        ! args
+        real(c_double), intent(in) :: x(x__len_)
+        real(c_double), intent(out) :: out
+        ! manifest end
+      
+        interface
+          function unif_rand() bind(c, name = "unif_rand") result(u)
+            use iso_c_binding, only: c_double
+            real(c_double) :: u
+          end function unif_rand
+        end interface
+      
+      
+        out = x((int((unif_rand() * 3_c_int), kind=c_int) + 1_c_int))
+      end subroutine
+    Code
+      cat(cwrapper)
+    Output
+      #define R_NO_REMAP
+      #include <R.h>
+      #include <Rinternals.h>
+      #include <R_ext/Random.h>
+      
+      
+      extern void fn(
+        const double* const x__, 
+        double* const out__, 
+        const R_xlen_t x__len_);
+      
+      SEXP fn_(SEXP _args) {
+        // x
+        _args = CDR(_args);
+        SEXP x = CAR(_args);
+        if (TYPEOF(x) != REALSXP) {
+          Rf_error("typeof(x) must be 'double', not '%s'", Rf_type2char(TYPEOF(x)));
+        }
+        const double* const x__ = REAL(x);
+        const R_xlen_t x__len_ = Rf_xlength(x);
+        
+        const R_xlen_t out__len_ = (1);
+        SEXP out = PROTECT(Rf_allocVector(REALSXP, out__len_));
+        double* out__ = REAL(out);
+        
+        GetRNGstate();
+        fn(x__, out__, x__len_);
+        PutRNGstate();
+        
+        UNPROTECT(1);
+        return out;
+      }
+
+# c() promotes mixed elements
+
+    Code
+      fn
+    Output
+      function(x) {
+          declare(type(x = integer(n)))
+          c(1L, 2.5, x)
+        }
+      <environment: 0x0>
+    Code
+      cat(fsub)
+    Output
+      subroutine fn(x, out_, x__len_) bind(c)
+        use iso_c_binding, only: c_double, c_int, c_ptrdiff_t
+        implicit none
+      
+        ! manifest start
+        ! sizes
+        integer(c_ptrdiff_t), intent(in), value :: x__len_
+      
+        ! args
+        integer(c_int), intent(in) :: x(x__len_)
+        real(c_double), intent(out) :: out_((2 + x__len_))
+        ! manifest end
+      
+      
+        out_ = [ real(1_c_int, kind=c_double), 2.5_c_double, real(x, kind=c_double) ]
+      end subroutine
+    Code
+      cat(cwrapper)
+    Output
+      #define R_NO_REMAP
+      #include <R.h>
+      #include <Rinternals.h>
+      
+      
+      extern void fn(
+        const int* const x__, 
+        double* const out___, 
+        const R_xlen_t x__len_);
+      
+      SEXP fn_(SEXP _args) {
+        // x
+        _args = CDR(_args);
+        SEXP x = CAR(_args);
+        if (TYPEOF(x) != INTSXP) {
+          Rf_error("typeof(x) must be 'integer', not '%s'", Rf_type2char(TYPEOF(x)));
+        }
+        const int* const x__ = INTEGER(x);
+        const R_xlen_t x__len_ = Rf_xlength(x);
+        
+        const R_xlen_t out___len_ = (2 + x__len_);
+        SEXP out_ = PROTECT(Rf_allocVector(REALSXP, out___len_));
+        double* out___ = REAL(out_);
+        
+        fn(x__, out___, x__len_);
+        
+        UNPROTECT(1);
+        return out_;
+      }
+
+# multi-arg max()/min() promote
+
+    Code
+      fn
+    Output
+      function(x) {
+          declare(type(x = integer(n)))
+          max(x, 2.5)
+        }
+      <environment: 0x0>
+    Code
+      cat(fsub)
+    Output
+      subroutine fn(x, out_, x__len_) bind(c)
+        use iso_c_binding, only: c_double, c_int, c_ptrdiff_t
+        implicit none
+      
+        ! manifest start
+        ! sizes
+        integer(c_ptrdiff_t), intent(in), value :: x__len_
+      
+        ! args
+        integer(c_int), intent(in) :: x(x__len_)
+        real(c_double), intent(out) :: out_
+        ! manifest end
+      
+      
+        out_ = max(real(maxval(x), kind=c_double), 2.5_c_double)
+      end subroutine
+    Code
+      cat(cwrapper)
+    Output
+      #define R_NO_REMAP
+      #include <R.h>
+      #include <Rinternals.h>
+      
+      
+      extern void fn(
+        const int* const x__, 
+        double* const out___, 
+        const R_xlen_t x__len_);
+      
+      SEXP fn_(SEXP _args) {
+        // x
+        _args = CDR(_args);
+        SEXP x = CAR(_args);
+        if (TYPEOF(x) != INTSXP) {
+          Rf_error("typeof(x) must be 'integer', not '%s'", Rf_type2char(TYPEOF(x)));
+        }
+        const int* const x__ = INTEGER(x);
+        const R_xlen_t x__len_ = Rf_xlength(x);
+        
+        const R_xlen_t out___len_ = (1);
+        SEXP out_ = PROTECT(Rf_allocVector(REALSXP, out___len_));
+        double* out___ = REAL(out_);
+        
+        fn(x__, out___, x__len_);
+        
+        UNPROTECT(1);
+        return out_;
+      }
+
+# %% and %/% with mixed modes promote
+
+    Code
+      fn
+    Output
+      function(a, b) {
+          declare(type(a = integer(n)), type(b = double(n)))
+          a %% b
+        }
+      <environment: 0x0>
+    Code
+      cat(fsub)
+    Output
+      subroutine fn(a, b, out_, a__len_) bind(c)
+        use iso_c_binding, only: c_double, c_int, c_ptrdiff_t
+        implicit none
+      
+        ! manifest start
+        ! sizes
+        integer(c_ptrdiff_t), intent(in), value :: a__len_
+      
+        ! args
+        integer(c_int), intent(in) :: a(a__len_)
+        real(c_double), intent(in) :: b(a__len_)
+        real(c_double), intent(out) :: out_(a__len_)
+        ! manifest end
+      
+      
+        out_ = modulo(real(a, kind=c_double), b)
+      end subroutine
+    Code
+      cat(cwrapper)
+    Output
+      #define R_NO_REMAP
+      #include <R.h>
+      #include <Rinternals.h>
+      
+      
+      extern void fn(
+        const int* const a__, 
+        const double* const b__, 
+        double* const out___, 
+        const R_xlen_t a__len_);
+      
+      SEXP fn_(SEXP _args) {
+        // a
+        _args = CDR(_args);
+        SEXP a = CAR(_args);
+        if (TYPEOF(a) != INTSXP) {
+          Rf_error("typeof(a) must be 'integer', not '%s'", Rf_type2char(TYPEOF(a)));
+        }
+        const int* const a__ = INTEGER(a);
+        const R_xlen_t a__len_ = Rf_xlength(a);
+        
+        // b
+        _args = CDR(_args);
+        SEXP b = CAR(_args);
+        if (TYPEOF(b) != REALSXP) {
+          Rf_error("typeof(b) must be 'double', not '%s'", Rf_type2char(TYPEOF(b)));
+        }
+        const double* const b__ = REAL(b);
+        const R_xlen_t b__len_ = Rf_xlength(b);
+        
+        if (a__len_ != b__len_)
+          Rf_error("length(b) must equal length(a),"
+                   " but are %0.f and %0.f",
+                    (double)b__len_, (double)a__len_);
+        const R_xlen_t out___len_ = a__len_;
+        SEXP out_ = PROTECT(Rf_allocVector(REALSXP, out___len_));
+        double* out___ = REAL(out_);
+        
+        fn(
+          a__,
+          b__,
+          out___,
+          a__len_);
+        
+        UNPROTECT(1);
+        return out_;
+      }
+
+# ^ always returns double; integer exponent stays exact
+
+    Code
+      fn
+    Output
+      function(x) {
+          declare(type(x = integer(1)))
+          x ^ -1L
+        }
+      <environment: 0x0>
+    Code
+      cat(fsub)
+    Output
+      subroutine fn(x, out_) bind(c)
+        use iso_c_binding, only: c_double, c_int
+        implicit none
+      
+        ! manifest start
+        ! args
+        integer(c_int), intent(in) :: x
+        real(c_double), intent(out) :: out_
+        ! manifest end
+      
+      
+        out_ = (real(x, kind=c_double) ** (-1_c_int))
+      end subroutine
+    Code
+      cat(cwrapper)
+    Output
+      #define R_NO_REMAP
+      #include <R.h>
+      #include <Rinternals.h>
+      
+      
+      extern void fn(const int* const x__, double* const out___);
+      
+      SEXP fn_(SEXP _args) {
+        // x
+        _args = CDR(_args);
+        SEXP x = CAR(_args);
+        if (TYPEOF(x) != INTSXP) {
+          Rf_error("typeof(x) must be 'integer', not '%s'", Rf_type2char(TYPEOF(x)));
+        }
+        const int* const x__ = INTEGER(x);
+        const R_xlen_t x__len_ = Rf_xlength(x);
+        
+        if (x__len_ != 1)
+          Rf_error("length(x) must be 1, not %0.f",
+                    (double)x__len_);
+        const R_xlen_t out___len_ = (1);
+        SEXP out_ = PROTECT(Rf_allocVector(REALSXP, out___len_));
+        double* out___ = REAL(out_);
+        
+        fn(x__, out___);
+        
+        UNPROTECT(1);
+        return out_;
+      }
+
+# logical operands participate in arithmetic as integers
+
+    Code
+      fn
+    Output
+      function(a, b) {
+          declare(type(a = logical(1)), type(b = logical(1)))
+          a + b
+        }
+      <environment: 0x0>
+    Code
+      cat(fsub)
+    Output
+      subroutine fn(a, b, out_) bind(c)
+        use iso_c_binding, only: c_int
+        implicit none
+      
+        ! manifest start
+        ! args
+        integer(c_int), intent(in) :: a ! logical
+        integer(c_int), intent(in) :: b ! logical
+        integer(c_int), intent(out) :: out_
+        ! manifest end
+      
+      
+        out_ = (merge(1_c_int, 0_c_int, (a/=0)) + merge(1_c_int, 0_c_int, (b/=0)))
+      end subroutine
+    Code
+      cat(cwrapper)
+    Output
+      #define R_NO_REMAP
+      #include <R.h>
+      #include <Rinternals.h>
+      
+      
+      extern void fn(
+        const int* const a__, 
+        const int* const b__, 
+        int* const out___);
+      
+      SEXP fn_(SEXP _args) {
+        // a
+        _args = CDR(_args);
+        SEXP a = CAR(_args);
+        if (TYPEOF(a) != LGLSXP) {
+          Rf_error("typeof(a) must be 'logical', not '%s'", Rf_type2char(TYPEOF(a)));
+        }
+        const int* const a__ = LOGICAL(a);
+        const R_xlen_t a__len_ = Rf_xlength(a);
+        
+        // b
+        _args = CDR(_args);
+        SEXP b = CAR(_args);
+        if (TYPEOF(b) != LGLSXP) {
+          Rf_error("typeof(b) must be 'logical', not '%s'", Rf_type2char(TYPEOF(b)));
+        }
+        const int* const b__ = LOGICAL(b);
+        const R_xlen_t b__len_ = Rf_xlength(b);
+        
+        if (a__len_ != 1)
+          Rf_error("length(a) must be 1, not %0.f",
+                    (double)a__len_);
+        if (b__len_ != 1)
+          Rf_error("length(b) must be 1, not %0.f",
+                    (double)b__len_);
+        const R_xlen_t out___len_ = (1);
+        SEXP out_ = PROTECT(Rf_allocVector(INTSXP, out___len_));
+        int* out___ = INTEGER(out_);
+        
+        fn(a__, b__, out___);
+        
+        UNPROTECT(1);
+        return out_;
+      }
+

--- a/tests/testthat/test-div-mod.R
+++ b/tests/testthat/test-div-mod.R
@@ -55,3 +55,23 @@ test_that("integer %/% is exact beyond 2^24", {
     list(.Machine$integer.max, 7L)
   )
 })
+
+test_that("double %/% stays exact beyond integer range", {
+  div_dbl_big <- function(a, b) {
+    declare(type(a = double(1)), type(b = double(1)))
+    a %/% b
+  }
+
+  # locks the real-domain flooring: Fortran FLOOR() returns an integer, so
+  # e.g. 1e20 %/% 3 came back as -2147483648 instead of ~3.33e19
+  expect_translation_snapshots(div_dbl_big)
+
+  expect_quick_equal(
+    div_dbl_big,
+    list(1e20, 3),
+    list(-1e20, 3),
+    list(7.5, 2.5),
+    list(-7.5, 2.5),
+    list(-7, 2.5)
+  )
+})

--- a/tests/testthat/test-type-promotion.R
+++ b/tests/testthat/test-type-promotion.R
@@ -1,0 +1,177 @@
+# Unit tests for type promotion: result modes follow R's lattice
+# (logical < integer < double < complex) and operands are cast wherever
+# Fortran requires same-typed arguments.
+
+skip_on_cran()
+
+test_that("integer + double promotes to double", {
+  fn <- function(x) {
+    declare(type(x = integer(n)))
+    x + 0.5
+  }
+  # R returns doubles; the misreported integer mode used to declare an
+  # integer output and silently truncate
+  expect_translation_snapshots(fn)
+  expect_quick_equal(fn, list(-2:2))
+})
+
+test_that("real-valued RHS with integer operand declares a double binding", {
+  fn <- function(x) {
+    declare(type(x = double(1)))
+    out <- x * 3L
+    out
+  }
+  expect_translation_snapshots(fn)
+  expect_quick_equal(fn, list(0.5))
+})
+
+test_that("misreported mode does not defeat subscript coercion", {
+  # `runif(1) * 3L` is real-valued but used to report mode integer, so the
+  # `[` handler's double-coercion backstop never fired and the raw real
+  # expression landed in the subscript
+  fn <- function(x) {
+    declare(type(x = double(NA)))
+    out <- x[as.integer(runif(1) * 3) + 1L]
+    out
+  }
+  expect_translation_snapshots(fn)
+  qfn <- quick(fn)
+  x <- c(10, 20, 30)
+  set.seed(42)
+  r_res <- fn(x)
+  set.seed(42)
+  q_res <- qfn(x)
+  expect_identical(q_res, r_res)
+})
+
+test_that("c() promotes mixed elements", {
+  fn <- function(x) {
+    declare(type(x = integer(n)))
+    c(1L, 2.5, x)
+  }
+  # mixed-mode array constructors used to be a gfortran type error
+  expect_translation_snapshots(fn)
+  expect_quick_equal(fn, list(1:3))
+
+  fn_lgl <- function(x) {
+    declare(type(x = logical(1)))
+    c(x, 2L)
+  }
+  expect_quick_equal(fn_lgl, list(TRUE))
+})
+
+test_that("multi-arg max()/min() promote", {
+  fn <- function(x) {
+    declare(type(x = integer(n)))
+    max(x, 2.5)
+  }
+  # mixed-mode max()/min() used to be a gfortran type error
+  expect_translation_snapshots(fn)
+  expect_quick_equal(fn, list(1:3), list(5:9))
+
+  fn_min <- function(x) {
+    declare(type(x = integer(n)))
+    min(x, 2.5)
+  }
+  expect_quick_equal(fn_min, list(1:3), list(5:9))
+
+  fn_sum <- function(x) {
+    declare(type(x = integer(n)))
+    sum(x, 0.5)
+  }
+  expect_quick_equal(fn_sum, list(1:3))
+})
+
+test_that("%% and %/% with mixed modes promote", {
+  fn <- function(a, b) {
+    declare(type(a = integer(n)), type(b = double(n)))
+    a %% b
+  }
+  # modulo() requires same-typed args; this used to be a gfortran type error
+  expect_translation_snapshots(fn)
+  expect_quick_equal(fn, list(-5:5, rep(2.5, 11)))
+
+  fn_intdiv <- function(a, b) {
+    declare(type(a = integer(n)), type(b = double(n)))
+    a %/% b
+  }
+  expect_quick_equal(fn_intdiv, list(-5:5, rep(2.5, 11)))
+})
+
+test_that("^ always returns double; integer exponent stays exact", {
+  fn <- function(x) {
+    declare(type(x = integer(1)))
+    x ^ -1L
+  }
+  # locks the `** (...)` parenthesization and the double result mode:
+  # integer ** used to return integer (R: 0.5, bug: 0) through
+  # non-standard `** -1_c_int` syntax
+  expect_translation_snapshots(fn)
+  expect_quick_equal(fn, list(2L))
+
+  fn2 <- function(x) {
+    declare(type(x = integer(n)))
+    x ^ 2L
+  }
+  expect_quick_equal(fn2, list(-3:3))
+
+  fn3 <- function(x) {
+    declare(type(x = double(1)))
+    x ^ 2L
+  }
+  # negative base with whole-number exponent is defined in R (and in
+  # Fortran's real ** int, unlike real ** real)
+  expect_quick_equal(fn3, list(-2), list(2.5))
+
+  fn4 <- function(x) {
+    declare(type(x = double(1)))
+    x ^ 2.5
+  }
+  expect_quick_equal(fn4, list(2))
+})
+
+test_that("logical operands participate in arithmetic as integers", {
+  fn <- function(a, b) {
+    declare(type(a = logical(1)), type(b = logical(1)))
+    a + b
+  }
+  # R: TRUE + TRUE is 2L; Fortran has no logical arithmetic, so this used
+  # to be a gfortran type error
+  expect_translation_snapshots(fn)
+  expect_quick_equal(fn, list(TRUE, TRUE), list(TRUE, FALSE))
+
+  fn_mixed <- function(a, x) {
+    declare(type(a = logical(n)), type(x = double(n)))
+    a * x
+  }
+  expect_quick_equal(fn_mixed, list(c(TRUE, FALSE, TRUE), c(1.5, 2.5, 3.5)))
+
+  fn_neg <- function(a) {
+    declare(type(a = logical(1)))
+    -a
+  }
+  # R: -TRUE is -1L
+  expect_quick_equal(fn_neg, list(TRUE), list(FALSE))
+
+  fn_pow <- function(a, b) {
+    declare(type(a = logical(1)), type(b = logical(1)))
+    a ^ b
+  }
+  # R: TRUE ^ TRUE is 1 (double)
+  expect_quick_equal(fn_pow, list(TRUE, TRUE), list(FALSE, TRUE))
+})
+
+test_that("comparisons accept logical operands like R", {
+  fn <- function(x) {
+    declare(type(x = logical(n)))
+    x > 0L
+  }
+  # R compares logicals as integers; `.true. > 0` is not Fortran
+  expect_quick_equal(fn, list(c(TRUE, FALSE)))
+
+  fn_eq <- function(x, y) {
+    declare(type(x = logical(n)), type(y = logical(n)))
+    x == y
+  }
+  expect_quick_equal(fn_eq, list(c(TRUE, FALSE, TRUE), c(TRUE, TRUE, FALSE)))
+})

--- a/tests/testthat/test-type-promotion.R
+++ b/tests/testthat/test-type-promotion.R
@@ -101,7 +101,7 @@ test_that("%% and %/% with mixed modes promote", {
 test_that("^ always returns double; integer exponent stays exact", {
   fn <- function(x) {
     declare(type(x = integer(1)))
-    x ^ -1L
+    x^-1L
   }
   # locks the `** (...)` parenthesization and the double result mode:
   # integer ** used to return integer (R: 0.5, bug: 0) through
@@ -111,13 +111,13 @@ test_that("^ always returns double; integer exponent stays exact", {
 
   fn2 <- function(x) {
     declare(type(x = integer(n)))
-    x ^ 2L
+    x^2L
   }
   expect_quick_equal(fn2, list(-3:3))
 
   fn3 <- function(x) {
     declare(type(x = double(1)))
-    x ^ 2L
+    x^2L
   }
   # negative base with whole-number exponent is defined in R (and in
   # Fortran's real ** int, unlike real ** real)
@@ -125,7 +125,7 @@ test_that("^ always returns double; integer exponent stays exact", {
 
   fn4 <- function(x) {
     declare(type(x = double(1)))
-    x ^ 2.5
+    x^2.5
   }
   expect_quick_equal(fn4, list(2))
 })
@@ -155,7 +155,7 @@ test_that("logical operands participate in arithmetic as integers", {
 
   fn_pow <- function(a, b) {
     declare(type(a = logical(1)), type(b = logical(1)))
-    a ^ b
+    a^b
   }
   # R: TRUE ^ TRUE is 1 (double)
   expect_quick_equal(fn_pow, list(TRUE, TRUE), list(FALSE, TRUE))

--- a/tests/testthat/test-type-promotion.R
+++ b/tests/testthat/test-type-promotion.R
@@ -201,3 +201,29 @@ test_that("reassignment that would narrow the mode is a compile error", {
   }
   expect_quick_equal(fn_ok, list(1.5))
 })
+
+test_that("subassignment that would narrow the mode is a compile error", {
+  fn <- function(x) {
+    declare(type(x = integer(3)))
+    x[1L] <- 2.5
+    x
+  }
+  # R promotes the whole vector to double; the emitted element assignment
+  # used to silently truncate (quickr returned c(2L, 2L, 3L))
+  expect_error(quick(fn), "narrow double to integer")
+
+  fn_range <- function(x) {
+    declare(type(x = integer(n)))
+    x[1:2] <- x[1:2] / 2
+    x
+  }
+  expect_error(quick(fn_range), "narrow double to integer")
+
+  # widening-safe subassignment still works
+  fn_ok <- function(x) {
+    declare(type(x = double(3)))
+    x[1L] <- 5L
+    x
+  }
+  expect_quick_equal(fn_ok, list(c(1.5, 2.5, 3.5)))
+})

--- a/tests/testthat/test-type-promotion.R
+++ b/tests/testthat/test-type-promotion.R
@@ -175,3 +175,29 @@ test_that("comparisons accept logical operands like R", {
   }
   expect_quick_equal(fn_eq, list(c(TRUE, FALSE, TRUE), c(TRUE, TRUE, FALSE)))
 })
+
+test_that("reassignment that would narrow the mode is a compile error", {
+  fn <- function(x) {
+    declare(type(x = integer(1)))
+    x <- x + 0.5
+    x
+  }
+  # R promotes x to double; Fortran cannot re-type a variable, and the
+  # assignment used to silently truncate (quickr returned 2, R returns 2.5)
+  expect_error(quick(fn), "narrow double to integer")
+
+  fn_lgl <- function(x) {
+    declare(type(x = logical(1)))
+    x <- x + 1L
+    x
+  }
+  expect_error(quick(fn_lgl), "narrow integer to logical")
+
+  # same-mode and widening-safe reassignments still work
+  fn_ok <- function(x) {
+    declare(type(x = double(1)))
+    x <- x + 1L
+    x
+  }
+  expect_quick_equal(fn_ok, list(1.5))
+})

--- a/tests/testthat/test-type-promotion.R
+++ b/tests/testthat/test-type-promotion.R
@@ -208,21 +208,25 @@ test_that("comparisons accept logical operands like R", {
 })
 
 test_that("reassignment that would narrow the mode is a compile error", {
-  fn <- function(x) {
-    declare(type(x = integer(1)))
-    x <- x + 0.5
-    x
-  }
   # R promotes x to double; Fortran cannot re-type a variable, and the
   # assignment used to silently truncate (quickr returned 2, R returns 2.5)
-  expect_error(quick(fn), "narrow double to integer")
+  expect_snapshot(
+    quick(function(x) {
+      declare(type(x = integer(1)))
+      x <- x + 0.5
+      x
+    }),
+    error = TRUE
+  )
 
-  fn_lgl <- function(x) {
-    declare(type(x = logical(1)))
-    x <- x + 1L
-    x
-  }
-  expect_error(quick(fn_lgl), "narrow integer to logical")
+  expect_snapshot(
+    quick(function(x) {
+      declare(type(x = logical(1)))
+      x <- x + 1L
+      x
+    }),
+    error = TRUE
+  )
 
   # same-mode and widening-safe reassignments still work
   fn_ok <- function(x) {
@@ -234,21 +238,25 @@ test_that("reassignment that would narrow the mode is a compile error", {
 })
 
 test_that("subassignment that would narrow the mode is a compile error", {
-  fn <- function(x) {
-    declare(type(x = integer(3)))
-    x[1L] <- 2.5
-    x
-  }
   # R promotes the whole vector to double; the emitted element assignment
   # used to silently truncate (quickr returned c(2L, 2L, 3L))
-  expect_error(quick(fn), "narrow double to integer")
+  expect_snapshot(
+    quick(function(x) {
+      declare(type(x = integer(3)))
+      x[1L] <- 2.5
+      x
+    }),
+    error = TRUE
+  )
 
-  fn_range <- function(x) {
-    declare(type(x = integer(n)))
-    x[1:2] <- x[1:2] / 2
-    x
-  }
-  expect_error(quick(fn_range), "narrow double to integer")
+  expect_snapshot(
+    quick(function(x) {
+      declare(type(x = integer(n)))
+      x[1:2] <- x[1:2] / 2
+      x
+    }),
+    error = TRUE
+  )
 
   # widening-safe subassignment still works
   fn_ok <- function(x) {

--- a/tests/testthat/test-type-promotion.R
+++ b/tests/testthat/test-type-promotion.R
@@ -161,6 +161,37 @@ test_that("logical operands participate in arithmetic as integers", {
   expect_quick_equal(fn_pow, list(TRUE, TRUE), list(FALSE, TRUE))
 })
 
+test_that("abs() and single-arg reductions accept logical operands like R", {
+  fn_abs <- function(x) {
+    declare(type(x = logical(n)))
+    abs(x)
+  }
+  # R: abs(logical) is integer; this used to emit abs((x /= 0)), which
+  # gfortran rejects because abs() requires a numeric argument
+  expect_translation_snapshots(fn_abs)
+  expect_quick_identical(fn_abs, list(c(TRUE, FALSE, TRUE)))
+
+  fn_sum <- function(x) {
+    declare(type(x = logical(n)))
+    sum(x)
+  }
+  # likewise sum((x /= 0)) was a gfortran type error; R: sum(logical) is
+  # integer
+  expect_quick_identical(fn_sum, list(c(TRUE, FALSE, TRUE)))
+
+  fn_max <- function(x) {
+    declare(type(x = logical(n)))
+    max(x)
+  }
+  expect_quick_identical(fn_max, list(c(TRUE, FALSE)))
+
+  fn_min <- function(x) {
+    declare(type(x = logical(n)))
+    min(x)
+  }
+  expect_quick_identical(fn_min, list(c(TRUE, FALSE)))
+})
+
 test_that("comparisons accept logical operands like R", {
   fn <- function(x) {
     declare(type(x = logical(n)))


### PR DESCRIPTION
> **Stacked PR 3 of 15** — branch `conformability/03-type-promotion`,
> cut from PR 2 (#138), branch `conformability/02-literal-kinds`.
> GitHub can only diff a fork branch against `main`, so until PR 2 merges
> this page also shows PRs 1–2's commits; the 7 commits new to *this* PR
> are `Report and apply promoted result modes in operators and constructors`
> … `Format with air`.
>
> Stack overview and suggested review order: #152.

Fixes #124.

## What changed

quickr now follows R's mode lattice (`logical < integer < double <
complex`) wherever two values combine. User-visible, before → after:

| Program | Before | After (= R) |
|---|---|---|
| `x + 0.5` (integer `x`) | integers, silently truncated | doubles |
| `out <- runif(1) * 3L` | `out` declared integer, value truncated | declared double |
| `x ^ -1L` (integer `x`) | `0` (integer `**`, non-standard syntax) | `0.5` (double) |
| `c(1L, 2.5, x)` / `max(x, 2.5)` / `5L %% 2.5` | gfortran type error | works, promoted like R |
| `TRUE + TRUE`, `-TRUE`, `x > 0L` (logical `x`) | gfortran type error | `2L`, `-1L`, logical — R's logical-as-integer rule |
| `abs(x)`, `sum(x)`, `min(x)`/`max(x)` (logical `x`) | gfortran type error (`abs((x/=0))`) | integer results, like R |
| `1e20 %/% 3` (doubles) | `-2147483648` (Fortran `FLOOR()` returns an integer, which overflows) | `3.33e19` — floored in the real domain, like the `floor()` handler |
| `x <- x + 0.5` (integer `x`) | silently truncated (`2` where R gives `2.5`) | compile error: "cannot reassign `x`: assignment would narrow double to integer; R would promote `x` to double" |
| `x[1L] <- 2.5` / `x <<- 0.5` / `x[i] <<- 0.5` (integer `x`) | silently truncated (`c(2L, 2L, 3L)` where R gives `c(2.5, 2, 3)`) | same compile error — subassignment and superassignment cannot re-type the base variable either |

The last two rows are a deliberate policy choice, not a translation: Fortran
cannot re-type a variable, so matching R is impossible — the honest options
are silent truncation (status quo) or a refusal. This PR errs. If you'd
rather have a warning, the check is one contained function
(`check_reassignment_narrowing()` in R/scope.R) and easy to downgrade.

## How

A small set of shared helpers in R/r2f-operators-helpers.R replaces
per-handler improvisation:

- `cast_to_mode(x, mode, context)` — the only place cast spellings live
  (`real(x, kind=c_double)`, `merge(1_c_int, 0_c_int, x)`, …). Handles
  bind(c) integer-backed logicals by relabeling instead of double-wrapping.
  Errors cleanly ("`c()` does not support coercion from complex to double")
  on casts it can't spell. `bind_cast_value()` in R/r2f-matrix.R folded
  into it — there is now exactly one casting code path.
- `promote_operands(args, context)` — join + cast in one step, used by
  `c()` (Fortran array constructors require uniform element types).
- `arith_join_mode(...)` — the join with R's logical-as-integer rule
  (`TRUE + TRUE` is `2L`). Paired with `cast_to_mode()` it uniforms the
  other same-type contexts: multi-arg `min`/`max`/`sum`/`prod`, the
  single-argument reductions and `abs()`, and `modulo` (`%%`).
- `promote_arith_pair(left, right, context)` — applies that rule to binary
  arithmetic and comparisons; a no-op unless a logical operand is present.

`conform()` reports the lattice join instead of the first non-scalar
operand's mode (the stale "we'll let `<-` handle that" comment is gone —
`<-` copies the reported mode into the declaration, so it never could).
The lattice gains `complex` as its top, so complex results no longer
depend on operand order.

The lattice itself is spelled once: a shared `mode_lattice` constant
with a `mode_rank()` helper backs both `reduce_promoted_mode()` (the
join takes the highest rank present) and the narrowing check (which
refuses rank decreases), so the two rules this PR ties together cannot
drift apart.

Per-handler, only what Fortran requires: plain int/double mixes in
`+ - * / ^` get **no** operand cast (Fortran's own promotion matches R —
avoiding pointless snapshot churn); logical operands are cast to integer
for arithmetic and comparisons; `^` casts the base to double and keeps an
integer exponent integer (`real ** int` is exact and defined for negative
bases, matching `R_pow`'s whole-number special case), with the exponent
parenthesized to fix the non-standard `x ** -1_c_int`. Double `%/%` adopts
the `floor()` handler's real-domain spelling (`aint` plus a `merge`
adjustment) instead of Fortran's integer-returning `FLOOR()`, hoisting the
quotient into a block temporary so it is evaluated once.

## Tests

New `tests/testthat/test-type-promotion.R`: every row of the table above
except the `<<-` variants (they exercise the same
`check_reassignment_narrowing()` call as `<-`), plus `%/%` mixed modes,
`TRUE ^ TRUE`, seeded RNG-subscript comparison
(the misreported-mode case that defeated the `[` handler's double-coercion
backstop), and the narrowing errors (reassignment and subassignment)
including their "widening is still fine" complements. A large-magnitude
double `%/%` case in `test-div-mod.R` locks the real-domain flooring,
parallel to the existing `2^24` integer case. `expect_quick_equal` asserts
`typeof()` identity, which is exactly the property these bugs violated.

Snapshot churn outside the new file: two hunks in
`_snaps/example-heat_diffusion.md`, where `dx ** 2.0_c_double` becomes
`real(dx, kind=c_double) ** (2.0_c_double)` (base cast + exponent parens),
and one hunk in `_snaps/div-mod.md`, where the existing double `%/%`
translation changes from `out_ = floor(a / b)` to the hoisted-quotient
real-domain form; runtime comparisons are unchanged in both.

## Notes for review

- **NEWS-worthy behavior changes:** (1) mixed-mode expressions now return
  what R returns (previously truncated or failed to compile); (2)
  narrowing (re/sub/super)assignment is now a compile error (previously
  silent truncation); (3) double `%/%` is exact for large quotients.
- The logical-as-integer rule is named once (`arith_join_mode()`) and
  shared by every consumer — the per-site inline spelling is how
  `abs()` and the single-argument reduction path got missed.
- R's `prod()` always returns double (even for integer input); quickr's
  returns the operand join mode. Preexisting, orthogonal to the logical
  fix, and left alone here.
- `ifelse()` branch promotion and `t()`/`diag()` mode preservation are
  deliberately not here; they build on these helpers and follow next.
- The mechanism commit and each policy/fix commit are independently
  revertable.