### PR TITLE
[4/15] Fix result modes in ifelse(), t(), and diag(); enforce ifelse() branch shapes

### DIFF
--- a/R/r2f-conditionals.R
+++ b/R/r2f-conditionals.R
@@ -33,7 +33,9 @@ ifelse_axis_verdict <- function(test_dim, branch_dim) {
 # natively; a non-scalar branch must match `test`'s shape, because
 # merge() requires conformable arguments and a runtime mismatch would
 # read past the shorter branch. Statically unequal dims are a compile
-# error; symbolic dims get a statement-level runtime size guard.
+# error; symbolic dims get a statement-level runtime size guard, emitted into
+# `hoist` -- always a live hoist context, since r2f() substitutes a fresh one
+# before dispatching to any handler.
 check_ifelse_branch_shape <- function(branch, mask, hoist, scope) {
   if (passes_as_scalar(branch@value)) {
     return(invisible())
@@ -56,13 +58,6 @@ check_ifelse_branch_shape <- function(branch, mask, hoist, scope) {
   }
   if (!length(unknown_axes)) {
     return(invisible())
-  }
-  if (is.null(hoist)) {
-    stop(
-      "cannot emit a runtime length guard here; ",
-      "ifelse() branch lengths must match `test` statically",
-      call. = FALSE
-    )
   }
   # size() is an inquiry, so applying it to operand expression text does
   # not evaluate the operands.

--- a/R/r2f-conditionals.R
+++ b/R/r2f-conditionals.R
@@ -1,16 +1,86 @@
 # r2f-conditionals.R
 # Handlers for vectorized conditionals: ifelse
 
+# --- Local Helpers ---
+
+ifelse_branch_shape_msg <- paste0(
+  "ifelse() `yes` and `no` must be scalars or match the shape of `test`; ",
+  "R-style recycling is not supported"
+)
+
+# Three-valued conformability verdict for one axis of an ifelse() branch
+# against `test`: ok+known (no guard), not-ok+known (compile error), or
+# unknown (runtime guard). NA dims are always unknown: two unknown lengths
+# are not the same quantity.
+ifelse_axis_verdict <- function(test_dim, branch_dim) {
+  if (is_wholenumber(test_dim) && is_wholenumber(branch_dim)) {
+    return(list(
+      ok = identical(as.integer(test_dim), as.integer(branch_dim)),
+      unknown = FALSE
+    ))
+  }
+  if (!is_scalar_na(test_dim) && !is_scalar_na(branch_dim)) {
+    test_norm <- fortranize_expr_symbols(test_dim)
+    branch_norm <- fortranize_expr_symbols(branch_dim)
+    if (identical(test_norm, branch_norm)) {
+      return(list(ok = TRUE, unknown = FALSE))
+    }
+  }
+  list(ok = TRUE, unknown = TRUE)
+}
+
+# Enforce the shape contract for one ifelse() branch: scalars broadcast
+# natively; a non-scalar branch must match `test`'s shape, because
+# merge() requires conformable arguments and a runtime mismatch would
+# read past the shorter branch. Statically unequal dims are a compile
+# error; symbolic dims get a statement-level runtime size guard.
+check_ifelse_branch_shape <- function(branch, mask, hoist, scope) {
+  if (passes_as_scalar(branch@value)) {
+    return(invisible())
+  }
+  if (branch@value@rank != mask@value@rank) {
+    stop(ifelse_branch_shape_msg, call. = FALSE)
+  }
+  unknown_axes <- integer()
+  for (axis in seq_len(mask@value@rank)) {
+    verdict <- ifelse_axis_verdict(
+      dim_or_one(mask, axis),
+      dim_or_one(branch, axis)
+    )
+    if (!verdict$ok) {
+      stop(ifelse_branch_shape_msg, call. = FALSE)
+    }
+    if (verdict$unknown) {
+      unknown_axes <- c(unknown_axes, axis)
+    }
+  }
+  if (!length(unknown_axes)) {
+    return(invisible())
+  }
+  if (is.null(hoist)) {
+    stop(
+      "cannot emit a runtime length guard here; ",
+      "ifelse() branch lengths must match `test` statically",
+      call. = FALSE
+    )
+  }
+  # size() is an inquiry, so applying it to operand expression text does
+  # not evaluate the operands.
+  condition <- str_flatten(
+    map_chr(
+      unknown_axes,
+      function(axis) glue("size({branch}, {axis}) /= size({mask}, {axis})")
+    ),
+    " .or. "
+  )
+  emit_quickr_error_if(condition, ifelse_branch_shape_msg, hoist, scope)
+  invisible()
+}
+
 # --- Handlers ---
 
-r2f_handlers[["ifelse"]] <- function(args, scope, ...) {
-  .[mask, tsource, fsource] <- lapply(args, r2f, scope, ...)
-  mask <- booleanize_logical_as_int(mask)
-
-  # merge() requires same-typed branches; promote both to their common mode.
-  promoted <- promote_operands(list(tsource, fsource), context = "ifelse()")
-  .[tsource, fsource] <- promoted$args
-  mode <- promoted$mode
+r2f_handlers[["ifelse"]] <- function(args, scope, ..., hoist = NULL) {
+  .[mask, tsource, fsource] <- lapply(args, r2f, scope, ..., hoist = hoist)
 
   # R: the result is shaped like `test` (branches only contribute values).
   # A scalar test with array branches is not representable with merge().
@@ -24,6 +94,17 @@ r2f_handlers[["ifelse"]] <- function(args, scope, ...) {
       call. = FALSE
     )
   }
+
+  # Checked before casts so guards splice the bare operand text.
+  check_ifelse_branch_shape(tsource, mask, hoist, scope)
+  check_ifelse_branch_shape(fsource, mask, hoist, scope)
+
+  mask <- booleanize_logical_as_int(mask)
+
+  # merge() requires same-typed branches; promote both to their common mode.
+  promoted <- promote_operands(list(tsource, fsource), context = "ifelse()")
+  .[tsource, fsource] <- promoted$args
+  mode <- promoted$mode
 
   Fortran(
     glue("merge({tsource}, {fsource}, {mask})"),

--- a/R/r2f-conditionals.R
+++ b/R/r2f-conditionals.R
@@ -6,8 +6,27 @@
 r2f_handlers[["ifelse"]] <- function(args, scope, ...) {
   .[mask, tsource, fsource] <- lapply(args, r2f, scope, ...)
   mask <- booleanize_logical_as_int(mask)
-  # (tsource, fsource, mask)
-  mode <- tsource@value@mode
-  dims <- conform(mask@value, tsource@value, fsource@value)@dims
-  Fortran(glue("merge({tsource}, {fsource}, {mask})"), Variable(mode, dims))
+
+  # merge() requires same-typed branches; promote both to their common mode.
+  promoted <- promote_operands(list(tsource, fsource), context = "ifelse()")
+  .[tsource, fsource] <- promoted$args
+  mode <- promoted$mode
+
+  # R: the result is shaped like `test` (branches only contribute values).
+  # A scalar test with array branches is not representable with merge().
+  if (
+    passes_as_scalar(mask@value) &&
+      !(passes_as_scalar(tsource@value) && passes_as_scalar(fsource@value))
+  ) {
+    stop(
+      "ifelse() result takes the shape of `test`; ",
+      "array-valued yes/no with scalar test is not supported",
+      call. = FALSE
+    )
+  }
+
+  Fortran(
+    glue("merge({tsource}, {fsource}, {mask})"),
+    Variable(mode, mask@value@dims)
+  )
 }

--- a/R/r2f-matrix-blas.R
+++ b/R/r2f-matrix-blas.R
@@ -262,12 +262,20 @@ can_use_output <- function(
   expected_dims = NULL,
   context,
   allow_alias = character(),
-  mode = "double"
+  mode = "double",
+  logical_is_c_int = FALSE
 ) {
+  stopifnot(
+    is_bool(logical_is_c_int),
+    !logical_is_c_int || identical(mode, "logical")
+  )
   if (is.null(dest)) {
     return(FALSE)
   }
   if (!identical(dest@mode, mode)) {
+    return(FALSE)
+  }
+  if (!identical(logical_as_int(dest), logical_is_c_int)) {
     return(FALSE)
   }
   assert_dest_dims_compatible(dest, expected_dims, context)
@@ -293,7 +301,8 @@ ensure_blas_operand_name <- function(x, hoist) {
   }
   tmp <- hoist$declare_tmp(
     mode = x@value@mode %||% "double",
-    dims = x@value@dims
+    dims = x@value@dims,
+    logical_as_int = logical_as_int(x@value)
   )
   hoist$emit(glue("{tmp@name} = {x}"))
   tmp@name
@@ -1199,6 +1208,7 @@ diag_extract <- function(x, scope, hoist, dest = NULL, context = "diag") {
   diag_len <- diag_length_expr(x_dims$rows, x_dims$cols, context)
 
   x_name <- ensure_blas_operand_name(x, hoist)
+  logical_is_c_int <- logical_as_int(x@value)
 
   writes_to_dest <- FALSE
   if (
@@ -1207,14 +1217,19 @@ diag_extract <- function(x, scope, hoist, dest = NULL, context = "diag") {
       input_names = x_name,
       expected_dims = list(diag_len),
       context = context,
-      mode = x@value@mode
+      mode = x@value@mode,
+      logical_is_c_int = logical_is_c_int
     )
   ) {
     out_var <- dest
     out_name <- dest@name
     writes_to_dest <- TRUE
   } else {
-    out_var <- hoist$declare_tmp(mode = x@value@mode, dims = list(diag_len))
+    out_var <- hoist$declare_tmp(
+      mode = x@value@mode,
+      dims = list(diag_len),
+      logical_as_int = logical_is_c_int
+    )
     out_name <- out_var@name
   }
 
@@ -1249,14 +1264,7 @@ diag_matrix <- function(
   assert_rank_leq1(x, paste0(context, " expects a vector or scalar input"))
 
   mode <- x@value@mode
-  zero <- switch(
-    mode,
-    double = "0.0_c_double",
-    integer = "0_c_int",
-    logical = ".false.",
-    complex = "(0.0_c_double, 0.0_c_double)",
-    stop(context, " does not support mode ", mode, call. = FALSE)
-  )
+  logical_is_c_int <- logical_as_int(x@value)
 
   diag_len <- diag_length_expr(nrow, ncol, context)
   x_scalar <- passes_as_scalar(x@value)
@@ -1271,17 +1279,30 @@ diag_matrix <- function(
       input_names = x_name,
       expected_dims = list(nrow, ncol),
       context = context,
-      mode = mode
+      mode = mode,
+      logical_is_c_int = logical_is_c_int
     )
   ) {
     out_var <- dest
     out_name <- dest@name
     writes_to_dest <- TRUE
   } else {
-    out_var <- hoist$declare_tmp(mode = mode, dims = list(nrow, ncol))
+    out_var <- hoist$declare_tmp(
+      mode = mode,
+      dims = list(nrow, ncol),
+      logical_as_int = logical_is_c_int
+    )
     out_name <- out_var@name
   }
 
+  zero <- switch(
+    mode,
+    double = "0.0_c_double",
+    integer = "0_c_int",
+    logical = if (logical_as_int(out_var)) "0_c_int" else ".false.",
+    complex = "(0.0_c_double, 0.0_c_double)",
+    stop(context, " does not support mode ", mode, call. = FALSE)
+  )
   hoist$emit(glue("{out_name} = {zero}"))
 
   idx_i <- hoist$declare_tmp(mode = "integer", dims = NULL)

--- a/R/r2f-matrix-blas.R
+++ b/R/r2f-matrix-blas.R
@@ -261,12 +261,13 @@ can_use_output <- function(
   input_names = character(),
   expected_dims = NULL,
   context,
-  allow_alias = character()
+  allow_alias = character(),
+  mode = "double"
 ) {
   if (is.null(dest)) {
     return(FALSE)
   }
-  if (!identical(dest@mode, "double")) {
+  if (!identical(dest@mode, mode)) {
     return(FALSE)
   }
   assert_dest_dims_compatible(dest, expected_dims, context)
@@ -1190,7 +1191,8 @@ lapack_chol2inv <- function(
 diag_extract <- function(x, scope, hoist, dest = NULL, context = "diag") {
   assert_hoist_env(hoist)
 
-  x <- maybe_cast_double(x)
+  # R's diag(<matrix>) preserves the input mode; the copy loop is
+  # mode-agnostic.
   assert_rank2_matrix(x, paste0(context, " expects a matrix input"))
 
   x_dims <- matrix_dims(x)
@@ -1204,14 +1206,15 @@ diag_extract <- function(x, scope, hoist, dest = NULL, context = "diag") {
       dest,
       input_names = x_name,
       expected_dims = list(diag_len),
-      context = context
+      context = context,
+      mode = x@value@mode
     )
   ) {
     out_var <- dest
     out_name <- dest@name
     writes_to_dest <- TRUE
   } else {
-    out_var <- hoist$declare_tmp(mode = "double", dims = list(diag_len))
+    out_var <- hoist$declare_tmp(mode = x@value@mode, dims = list(diag_len))
     out_name <- out_var@name
   }
 
@@ -1241,8 +1244,19 @@ diag_matrix <- function(
 ) {
   assert_hoist_env(hoist)
 
-  x <- maybe_cast_double(x)
+  # R's diag(x, ...) preserves typeof(x). The identity-matrix callers pass
+  # a synthesized 1.0_c_double, which keeps diag(n) double, as in R.
   assert_rank_leq1(x, paste0(context, " expects a vector or scalar input"))
+
+  mode <- x@value@mode
+  zero <- switch(
+    mode,
+    double = "0.0_c_double",
+    integer = "0_c_int",
+    logical = ".false.",
+    complex = "(0.0_c_double, 0.0_c_double)",
+    stop(context, " does not support mode ", mode, call. = FALSE)
+  )
 
   diag_len <- diag_length_expr(nrow, ncol, context)
   x_scalar <- passes_as_scalar(x@value)
@@ -1256,18 +1270,19 @@ diag_matrix <- function(
       dest,
       input_names = x_name,
       expected_dims = list(nrow, ncol),
-      context = context
+      context = context,
+      mode = mode
     )
   ) {
     out_var <- dest
     out_name <- dest@name
     writes_to_dest <- TRUE
   } else {
-    out_var <- hoist$declare_tmp(mode = "double", dims = list(nrow, ncol))
+    out_var <- hoist$declare_tmp(mode = mode, dims = list(nrow, ncol))
     out_name <- out_var@name
   }
 
-  hoist$emit(glue("{out_name} = 0.0_c_double"))
+  hoist$emit(glue("{out_name} = {zero}"))
 
   idx_i <- hoist$declare_tmp(mode = "integer", dims = NULL)
   value_expr <- if (x_scalar) {

--- a/R/r2f-matrix-infer.R
+++ b/R/r2f-matrix-infer.R
@@ -311,9 +311,14 @@ infer_dest_diag <- function(args, scope) {
 
   # Case: x is a matrix -> extract diagonal (returns vector)
   if (!is.null(x) && x@rank == 2L) {
+    if (is.null(x@mode)) {
+      return(NULL)
+    }
     x_dims <- matrix_dims_var(x)
     diag_len <- diag_length_expr(x_dims$rows, x_dims$cols, "diag")
-    return(Variable("double", list(diag_len)))
+    # diag_extract() preserves x's mode; a double-inferred dest would
+    # mislabel an integer diagonal.
+    return(Variable(x@mode, list(diag_len)))
   }
 
   # Case: x is a scalar literal (identity matrix of that size)
@@ -330,7 +335,8 @@ infer_dest_diag <- function(args, scope) {
   }
 
   # Case: x is a vector or scalar, construct diagonal matrix
-  if (!is.null(x) && x@rank <= 1L) {
+  # (diag_matrix() preserves x's mode, matching R)
+  if (!is.null(x) && x@rank <= 1L && !is.null(x@mode)) {
     if (has_nrow || has_ncol) {
       nrow <- if (has_nrow) infer_size(nrow_arg, scope) else NULL
       ncol <- if (has_ncol) infer_size(ncol_arg, scope) else NULL
@@ -343,12 +349,12 @@ infer_dest_diag <- function(args, scope) {
       if (is.null(ncol)) {
         ncol <- nrow
       }
-      return(Variable("double", list(nrow, ncol)))
+      return(Variable(x@mode, list(nrow, ncol)))
     }
     # No nrow/ncol: square matrix from vector length
     if (x@rank == 1L) {
       len <- var_dim_or_one(x, 1L)
-      return(Variable("double", list(len, len)))
+      return(Variable(x@mode, list(len, len)))
     }
   }
 

--- a/R/r2f-matrix-infer.R
+++ b/R/r2f-matrix-infer.R
@@ -318,7 +318,11 @@ infer_dest_diag <- function(args, scope) {
     diag_len <- diag_length_expr(x_dims$rows, x_dims$cols, "diag")
     # diag_extract() preserves x's mode; a double-inferred dest would
     # mislabel an integer diagonal.
-    return(Variable(x@mode, list(diag_len)))
+    return(Variable(
+      mode = x@mode,
+      dims = list(diag_len),
+      logical_as_int = logical_as_int(x)
+    ))
   }
 
   # Case: x is a scalar literal (identity matrix of that size)
@@ -349,12 +353,20 @@ infer_dest_diag <- function(args, scope) {
       if (is.null(ncol)) {
         ncol <- nrow
       }
-      return(Variable(x@mode, list(nrow, ncol)))
+      return(Variable(
+        mode = x@mode,
+        dims = list(nrow, ncol),
+        logical_as_int = logical_as_int(x)
+      ))
     }
     # No nrow/ncol: square matrix from vector length
     if (x@rank == 1L) {
       len <- var_dim_or_one(x, 1L)
-      return(Variable(x@mode, list(len, len)))
+      return(Variable(
+        mode = x@mode,
+        dims = list(len, len),
+        logical_as_int = logical_as_int(x)
+      ))
     }
   }
 

--- a/R/r2f-matrix-parse.R
+++ b/R/r2f-matrix-parse.R
@@ -1,6 +1,9 @@
 # Matrix parsing helpers
 
 # Unwrap t() calls to infer transpose flags and normalize scalars/vectors.
+# The double casts here are correct and intentional: this path only feeds
+# matrix-multiplication handlers (%*%, crossprod, ...), and R's matrix
+# products always return double. The standalone t() handler preserves mode.
 unwrap_transpose_arg <- function(arg, scope, ..., hoist) {
   arg_unwrapped <- unwrap_parens(arg)
   if (is_call(arg_unwrapped, quote(t)) && length(arg_unwrapped) == 2L) {

--- a/R/r2f-matrix.R
+++ b/R/r2f-matrix.R
@@ -137,13 +137,14 @@ register_r2f_handler(
 r2f_handlers[["t"]] <- function(args, scope, ..., hoist = NULL) {
   stopifnot(length(args) == 1L)
   x <- r2f(args[[1L]], scope, ..., hoist = hoist)
-  x <- maybe_cast_double(x)
+  # R's t() preserves the input mode. (The transposes feeding matrix
+  # multiplication go through unwrap_transpose_arg(), not this handler.)
   if (x@value@rank == 2) {
-    val <- Variable("double", list(x@value@dims[[2]], x@value@dims[[1]]))
+    val <- Variable(x@value@mode, list(x@value@dims[[2]], x@value@dims[[1]]))
     return(Fortran(glue("transpose({x})"), val))
   } else if (x@value@rank == 1) {
     len <- x@value@dims[[1]]
-    val <- Variable("double", list(1L, len))
+    val <- Variable(x@value@mode, list(1L, len))
     return(Fortran(glue("reshape({x}, [1, int({len})])"), val))
   } else if (x@value@rank == 0) {
     return(x)

--- a/tests/testthat/_snaps/ifelse.md
+++ b/tests/testthat/_snaps/ifelse.md
@@ -79,3 +79,132 @@
         return out_;
       }
 
+# ifelse guards unknown branch lengths at runtime
+
+    Code
+      fn
+    Output
+      function(c, a, b) {
+          declare(type(c = logical(NA)), type(a = double(NA)), type(b = double(NA)))
+          ifelse(c, a, b)
+        }
+      <environment: 0x0>
+    Code
+      cat(fsub)
+    Output
+      subroutine fn(c, a, b, out_, a__len_, b__len_, c__len_, quickr_err_msg) bind(c)
+        use iso_c_binding, only: c_char, c_double, c_int, c_null_char, c_ptrdiff_t
+        implicit none
+      
+        ! manifest start
+        ! sizes
+        integer(c_ptrdiff_t), intent(in), value :: c__len_
+        integer(c_ptrdiff_t), intent(in), value :: a__len_
+        integer(c_ptrdiff_t), intent(in), value :: b__len_
+      
+        ! error
+        character(kind=c_char), intent(inout) :: quickr_err_msg(256)
+      
+        ! args
+        integer(c_int), intent(in) :: c(c__len_) ! logical
+        real(c_double), intent(in) :: a(a__len_)
+        real(c_double), intent(in) :: b(b__len_)
+        real(c_double), intent(out) :: out_(c__len_)
+        ! manifest end
+      
+      
+        if (size(a, 1) /= size((c/=0), 1)) then
+      call quickr_set_error_msg("ifelse() `yes` and `no` must be scalars or match the shape of `test`; R-style recycling is not&
+      & supported")
+          return
+        end if
+        if (size(b, 1) /= size((c/=0), 1)) then
+      call quickr_set_error_msg("ifelse() `yes` and `no` must be scalars or match the shape of `test`; R-style recycling is not&
+      & supported")
+          return
+        end if
+        out_ = merge(a, b, (c/=0))
+      
+        contains
+          subroutine quickr_set_error_msg(msg)
+            character(len=*), intent(in) :: msg
+            integer :: i
+            integer :: n
+            if (quickr_err_msg(1) == c_null_char) then
+              n = min(len(msg), 256 - 1)
+              quickr_err_msg(1:n) = [(msg(i:i), i = 1, n)]
+              quickr_err_msg(n + 1) = c_null_char
+            end if
+          end subroutine quickr_set_error_msg
+      end subroutine
+    Code
+      cat(cwrapper)
+    Output
+      #define R_NO_REMAP
+      #include <R.h>
+      #include <Rinternals.h>
+      
+      
+      extern void fn(
+        const int* const c__, 
+        const double* const a__, 
+        const double* const b__, 
+        double* const out___, 
+        const R_xlen_t a__len_, 
+        const R_xlen_t b__len_, 
+        const R_xlen_t c__len_, 
+        char* quickr_err_msg);
+      
+      SEXP fn_(SEXP _args) {
+        // c
+        _args = CDR(_args);
+        SEXP c = CAR(_args);
+        if (TYPEOF(c) != LGLSXP) {
+          Rf_error("typeof(c) must be 'logical', not '%s'", Rf_type2char(TYPEOF(c)));
+        }
+        const int* const c__ = LOGICAL(c);
+        const R_xlen_t c__len_ = Rf_xlength(c);
+        
+        // a
+        _args = CDR(_args);
+        SEXP a = CAR(_args);
+        if (TYPEOF(a) != REALSXP) {
+          Rf_error("typeof(a) must be 'double', not '%s'", Rf_type2char(TYPEOF(a)));
+        }
+        const double* const a__ = REAL(a);
+        const R_xlen_t a__len_ = Rf_xlength(a);
+        
+        // b
+        _args = CDR(_args);
+        SEXP b = CAR(_args);
+        if (TYPEOF(b) != REALSXP) {
+          Rf_error("typeof(b) must be 'double', not '%s'", Rf_type2char(TYPEOF(b)));
+        }
+        const double* const b__ = REAL(b);
+        const R_xlen_t b__len_ = Rf_xlength(b);
+        
+        const R_xlen_t out___len_ = c__len_;
+        SEXP out_ = PROTECT(Rf_allocVector(REALSXP, out___len_));
+        double* out___ = REAL(out_);
+        
+        char quickr_err_msg[256];
+        quickr_err_msg[0] = '\0';
+        
+        
+        fn(
+          c__,
+          a__,
+          b__,
+          out___,
+          a__len_,
+          b__len_,
+          c__len_,
+          quickr_err_msg);
+        if (quickr_err_msg[0] != '\0') {
+          Rf_error("%s", quickr_err_msg);
+        }
+        
+        UNPROTECT(1);
+        return out_;
+      }
+

--- a/tests/testthat/_snaps/ifelse.md
+++ b/tests/testthat/_snaps/ifelse.md
@@ -1,0 +1,81 @@
+# ifelse promotes branches and shapes like test
+
+    Code
+      fn
+    Output
+      function(c, a) {
+          declare(type(c = logical(n)), type(a = double(n)))
+          ifelse(c, 1L, a)
+        }
+      <environment: 0x0>
+    Code
+      cat(fsub)
+    Output
+      subroutine fn(c, a, out_, c__len_) bind(c)
+        use iso_c_binding, only: c_double, c_int, c_ptrdiff_t
+        implicit none
+      
+        ! manifest start
+        ! sizes
+        integer(c_ptrdiff_t), intent(in), value :: c__len_
+      
+        ! args
+        integer(c_int), intent(in) :: c(c__len_) ! logical
+        real(c_double), intent(in) :: a(c__len_)
+        real(c_double), intent(out) :: out_(c__len_)
+        ! manifest end
+      
+      
+        out_ = merge(real(1_c_int, kind=c_double), a, (c/=0))
+      end subroutine
+    Code
+      cat(cwrapper)
+    Output
+      #define R_NO_REMAP
+      #include <R.h>
+      #include <Rinternals.h>
+      
+      
+      extern void fn(
+        const int* const c__, 
+        const double* const a__, 
+        double* const out___, 
+        const R_xlen_t c__len_);
+      
+      SEXP fn_(SEXP _args) {
+        // c
+        _args = CDR(_args);
+        SEXP c = CAR(_args);
+        if (TYPEOF(c) != LGLSXP) {
+          Rf_error("typeof(c) must be 'logical', not '%s'", Rf_type2char(TYPEOF(c)));
+        }
+        const int* const c__ = LOGICAL(c);
+        const R_xlen_t c__len_ = Rf_xlength(c);
+        
+        // a
+        _args = CDR(_args);
+        SEXP a = CAR(_args);
+        if (TYPEOF(a) != REALSXP) {
+          Rf_error("typeof(a) must be 'double', not '%s'", Rf_type2char(TYPEOF(a)));
+        }
+        const double* const a__ = REAL(a);
+        const R_xlen_t a__len_ = Rf_xlength(a);
+        
+        if (c__len_ != a__len_)
+          Rf_error("length(a) must equal length(c),"
+                   " but are %0.f and %0.f",
+                    (double)a__len_, (double)c__len_);
+        const R_xlen_t out___len_ = c__len_;
+        SEXP out_ = PROTECT(Rf_allocVector(REALSXP, out___len_));
+        double* out___ = REAL(out_);
+        
+        fn(
+          c__,
+          a__,
+          out___,
+          c__len_);
+        
+        UNPROTECT(1);
+        return out_;
+      }
+

--- a/tests/testthat/_snaps/matrix.md
+++ b/tests/testthat/_snaps/matrix.md
@@ -231,3 +231,79 @@
         return out;
       }
 
+# t() and diag() preserve integer mode
+
+    Code
+      fn
+    Output
+      function(m) {
+          declare(type(m = integer(3, 3)))
+          out <- diag(m)
+          out
+        }
+      <environment: 0x0>
+    Code
+      cat(fsub)
+    Output
+      subroutine fn(m, out) bind(c)
+        use iso_c_binding, only: c_int
+        implicit none
+      
+        ! manifest start
+        ! args
+        integer(c_int), intent(in) :: m(3, 3)
+        integer(c_int), intent(out) :: out(3)
+        ! manifest end
+      
+      
+        block
+          integer(c_int) :: btmp1_
+      
+          do btmp1_ = 1_c_int, int(3, kind=c_int)
+            out(btmp1_) = m(btmp1_, btmp1_)
+          end do
+        end block
+      end subroutine
+    Code
+      cat(cwrapper)
+    Output
+      #define R_NO_REMAP
+      #include <R.h>
+      #include <Rinternals.h>
+      
+      
+      extern void fn(const int* const m__, int* const out__);
+      
+      SEXP fn_(SEXP _args) {
+        // m
+        _args = CDR(_args);
+        SEXP m = CAR(_args);
+        if (TYPEOF(m) != INTSXP) {
+          Rf_error("typeof(m) must be 'integer', not '%s'", Rf_type2char(TYPEOF(m)));
+        }
+        const int* const m__ = INTEGER(m);
+        const int* const m__dim_ = ({
+        SEXP dim_ = Rf_getAttrib(m, R_DimSymbol);
+        if (Rf_length(dim_) != 2) Rf_error(
+          "m must be a 2D-array, but length(dim(m)) is %i",
+          (int) Rf_length(dim_));
+        INTEGER(dim_);});
+        const int m__dim_1_ = m__dim_[0];
+        const int m__dim_2_ = m__dim_[1];
+        
+        if (m__dim_1_ != 3)
+          Rf_error("dim(m)[1] must be 3, not %0.f",
+                    (double)m__dim_1_);
+        if (m__dim_2_ != 3)
+          Rf_error("dim(m)[2] must be 3, not %0.f",
+                    (double)m__dim_2_);
+        const R_xlen_t out__len_ = 3;
+        SEXP out = PROTECT(Rf_allocVector(INTSXP, out__len_));
+        int* out__ = INTEGER(out);
+        
+        fn(m__, out__);
+        
+        UNPROTECT(1);
+        return out;
+      }
+

--- a/tests/testthat/_snaps/matrix.md
+++ b/tests/testthat/_snaps/matrix.md
@@ -307,3 +307,156 @@
         return out;
       }
 
+# diag() preserves integer-backed logical storage in an intermediate
+
+    Code
+      fn
+    Output
+      function(m) {
+          declare(type(m = logical(2, 2)))
+          d <- diag(m)
+          as.integer(d)
+        }
+      <environment: 0x0>
+    Code
+      cat(fsub)
+    Output
+      subroutine fn(m, out_) bind(c)
+        use iso_c_binding, only: c_int
+        implicit none
+      
+        ! manifest start
+        ! args
+        integer(c_int), intent(in) :: m(2, 2) ! logical
+        integer(c_int), intent(out) :: out_(2)
+      
+        ! locals
+        integer(c_int) :: d(2) ! logical
+        ! manifest end
+      
+      
+        block
+          integer(c_int) :: btmp1_
+      
+          do btmp1_ = 1_c_int, int(2, kind=c_int)
+            d(btmp1_) = m(btmp1_, btmp1_)
+          end do
+        end block
+        out_ = d
+      end subroutine
+    Code
+      cat(cwrapper)
+    Output
+      #define R_NO_REMAP
+      #include <R.h>
+      #include <Rinternals.h>
+      
+      
+      extern void fn(const int* const m__, int* const out___);
+      
+      SEXP fn_(SEXP _args) {
+        // m
+        _args = CDR(_args);
+        SEXP m = CAR(_args);
+        if (TYPEOF(m) != LGLSXP) {
+          Rf_error("typeof(m) must be 'logical', not '%s'", Rf_type2char(TYPEOF(m)));
+        }
+        const int* const m__ = LOGICAL(m);
+        const int* const m__dim_ = ({
+        SEXP dim_ = Rf_getAttrib(m, R_DimSymbol);
+        if (Rf_length(dim_) != 2) Rf_error(
+          "m must be a 2D-array, but length(dim(m)) is %i",
+          (int) Rf_length(dim_));
+        INTEGER(dim_);});
+        const int m__dim_1_ = m__dim_[0];
+        const int m__dim_2_ = m__dim_[1];
+        
+        if (m__dim_1_ != 2)
+          Rf_error("dim(m)[1] must be 2, not %0.f",
+                    (double)m__dim_1_);
+        if (m__dim_2_ != 2)
+          Rf_error("dim(m)[2] must be 2, not %0.f",
+                    (double)m__dim_2_);
+        const R_xlen_t out___len_ = 2;
+        SEXP out_ = PROTECT(Rf_allocVector(INTSXP, out___len_));
+        int* out___ = INTEGER(out_);
+        
+        fn(m__, out___);
+        
+        UNPROTECT(1);
+        return out_;
+      }
+
+# diag() initializes integer-backed logical outputs as integers
+
+    Code
+      fn
+    Output
+      function(x) {
+          declare(type(x = logical(2)))
+          diag(x, 3L, 4L)
+        }
+      <environment: 0x0>
+    Code
+      cat(fsub)
+    Output
+      subroutine fn(x, out_) bind(c)
+        use iso_c_binding, only: c_int
+        implicit none
+      
+        ! manifest start
+        ! args
+        integer(c_int), intent(in) :: x(2) ! logical
+        integer(c_int), intent(out) :: out_(3, 4) ! logical
+        ! manifest end
+      
+      
+        block
+          integer(c_int) :: btmp1_
+      
+          out_ = 0_c_int
+          do btmp1_ = 1_c_int, int(3, kind=c_int)
+            out_(btmp1_, btmp1_) = x(1_c_int + mod(btmp1_ - 1_c_int, int(2, kind=c_int)))
+          end do
+        end block
+      end subroutine
+    Code
+      cat(cwrapper)
+    Output
+      #define R_NO_REMAP
+      #include <R.h>
+      #include <Rinternals.h>
+      
+      
+      extern void fn(const int* const x__, int* const out___);
+      
+      SEXP fn_(SEXP _args) {
+        // x
+        _args = CDR(_args);
+        SEXP x = CAR(_args);
+        if (TYPEOF(x) != LGLSXP) {
+          Rf_error("typeof(x) must be 'logical', not '%s'", Rf_type2char(TYPEOF(x)));
+        }
+        const int* const x__ = LOGICAL(x);
+        const R_xlen_t x__len_ = Rf_xlength(x);
+        
+        if (x__len_ != 2)
+          Rf_error("length(x) must be 2, not %0.f",
+                    (double)x__len_);
+        const R_xlen_t out___len_ = (3) * (4);
+        SEXP out_ = PROTECT(Rf_allocVector(LGLSXP, out___len_));
+        int* out___ = LOGICAL(out_);
+        {
+          const SEXP _dim_sexp = PROTECT(Rf_allocVector(INTSXP, 2));
+          int* const _dim = INTEGER(_dim_sexp);
+          _dim[0] = 3;
+          _dim[1] = 4;
+          Rf_dimgets(out_, _dim_sexp);
+        }
+        
+        fn(x__, out___);
+        
+        UNPROTECT(2);
+        return out_;
+      }
+

--- a/tests/testthat/test-ifelse.R
+++ b/tests/testthat/test-ifelse.R
@@ -26,3 +26,27 @@ test_that("ifelse", {
   }
   expect_quick_equal(fn, list(seq(-5, 5, length.out = 20), double(20)))
 })
+
+test_that("ifelse promotes branches and shapes like test", {
+  fn <- function(c, a) {
+    declare(type(c = logical(n)), type(a = double(n)))
+    ifelse(c, 1L, a)
+  }
+  expect_translation_snapshots(fn)
+  expect_quick_equal(fn, list(c(TRUE, FALSE, TRUE), c(2, 4, 6)))
+
+  # logical branches join as logical
+  fn2 <- function(c, a) {
+    declare(type(c = logical(n)), type(a = logical(n)))
+    ifelse(c, FALSE, a)
+  }
+  expect_quick_equal(fn2, list(c(TRUE, FALSE, TRUE), c(TRUE, TRUE, FALSE)))
+})
+
+test_that("ifelse with scalar test and array branch errors cleanly", {
+  fn <- function(c, a) {
+    declare(type(c = logical(1)), type(a = double(n)))
+    ifelse(c, a, 0)
+  }
+  expect_error(quick(fn), "shape of `test`")
+})

--- a/tests/testthat/test-ifelse.R
+++ b/tests/testthat/test-ifelse.R
@@ -59,6 +59,23 @@ test_that("ifelse with statically mismatched branch lengths is a compile error",
   expect_error(quick(fn), "R-style recycling is not supported")
 })
 
+test_that("ifelse with a branch of different rank than test is a compile error", {
+  # merge() requires conformable arguments: a matrix branch under a vector
+  # `test` is R recycling, not broadcasting.
+  fn <- function(c, m) {
+    declare(type(c = logical(3)), type(m = double(3, 3)))
+    ifelse(c, m, 0)
+  }
+  expect_error(quick(fn), "R-style recycling is not supported")
+
+  # the mirror image, and in `no` position: a vector branch under a matrix test
+  fn2 <- function(c, a) {
+    declare(type(c = logical(2, 2)), type(a = double(4)))
+    ifelse(c, 0, a)
+  }
+  expect_error(quick(fn2), "R-style recycling is not supported")
+})
+
 test_that("ifelse guards unknown branch lengths at runtime", {
   fn <- function(c, a, b) {
     declare(type(c = logical(NA)), type(a = double(NA)), type(b = double(NA)))

--- a/tests/testthat/test-ifelse.R
+++ b/tests/testthat/test-ifelse.R
@@ -50,3 +50,31 @@ test_that("ifelse with scalar test and array branch errors cleanly", {
   }
   expect_error(quick(fn), "shape of `test`")
 })
+
+test_that("ifelse with statically mismatched branch lengths is a compile error", {
+  fn <- function(c, a) {
+    declare(type(c = logical(3)), type(a = double(2)))
+    ifelse(c, a, 0)
+  }
+  expect_error(quick(fn), "R-style recycling is not supported")
+})
+
+test_that("ifelse guards unknown branch lengths at runtime", {
+  fn <- function(c, a, b) {
+    declare(type(c = logical(NA)), type(a = double(NA)), type(b = double(NA)))
+    ifelse(c, a, b)
+  }
+  # locks the size guards: a bare merge() with runtime-mismatched
+  # assumed-shape vectors read past the shorter branch (returned garbage
+  # like 4.65e-310 where R recycles)
+  expect_translation_snapshots(fn)
+  qfn <- quick(fn)
+
+  cc <- c(TRUE, FALSE, TRUE)
+  a <- c(10, 20, 30)
+  b <- c(1, 2, 3)
+  expect_identical(qfn(cc, a, b), ifelse(cc, a, b))
+
+  expect_error(qfn(cc, c(10, 20), b), "match the shape of `test`")
+  expect_error(qfn(cc, a, c(1, 2, 3, 4)), "match the shape of `test`")
+})

--- a/tests/testthat/test-matrix.R
+++ b/tests/testthat/test-matrix.R
@@ -298,3 +298,68 @@ test_that("indexing function like transposed expressions hoists temporaries that
   x <- matrix(runif(25), 5, 5)
   expect_quick_identical(fn, list(x = x))
 })
+
+test_that("t() and diag() preserve integer mode", {
+  tfn <- function(m) {
+    declare(type(m = integer(2, 3)))
+    t(m)
+  }
+  expect_quick_equal(tfn, list(matrix(1:6, 2, 3))) # typeof integer
+
+  tvec <- function(x) {
+    declare(type(x = integer(3)))
+    t(x)
+  }
+  expect_quick_equal(tvec, list(1:3)) # R: 1 x 3 integer matrix
+
+  dfn <- function(m) {
+    declare(type(m = integer(3, 3)))
+    diag(m)
+  }
+  expect_quick_equal(dfn, list(matrix(1:9, 3, 3))) # R: integer vector
+
+  # same, through the inferred-destination path (out <- diag(m))
+  dfn2 <- function(m) {
+    declare(type(m = integer(3, 3)))
+    out <- diag(m)
+    out
+  }
+  expect_translation_snapshots(dfn2)
+  expect_quick_equal(dfn2, list(matrix(1:9, 3, 3)))
+
+  dvec <- function(x) {
+    declare(type(x = integer(3)))
+    diag(x)
+  }
+  expect_quick_equal(dvec, list(1:3)) # R: integer matrix
+
+  # x recycled along the diagonal of a non-square result
+  drect <- function(x) {
+    declare(type(x = integer(2)))
+    diag(x, 3L, 4L)
+  }
+  expect_quick_equal(drect, list(1:2))
+
+  # identity forms stay double, as in R
+  dident <- function() {
+    out <- diag(3L)
+    out
+  }
+  expect_quick_equal(dident, list())
+})
+
+test_that("t() and diag() preserve logical mode", {
+  m <- matrix(c(TRUE, FALSE, TRUE, TRUE), 2, 2)
+
+  tfn <- function(m) {
+    declare(type(m = logical(2, 2)))
+    t(m)
+  }
+  expect_quick_equal(tfn, list(m))
+
+  dfn <- function(m) {
+    declare(type(m = logical(2, 2)))
+    diag(m)
+  }
+  expect_quick_equal(dfn, list(m))
+})

--- a/tests/testthat/test-matrix.R
+++ b/tests/testthat/test-matrix.R
@@ -363,3 +363,31 @@ test_that("t() and diag() preserve logical mode", {
   }
   expect_quick_equal(dfn, list(m))
 })
+
+test_that("diag() preserves integer-backed logical storage in an intermediate", {
+  fn <- function(m) {
+    declare(type(m = logical(2, 2)))
+    d <- diag(m)
+    as.integer(d)
+  }
+
+  m <- matrix(c(TRUE, FALSE, TRUE, FALSE), 2, 2)
+  expect_match(
+    as.character(r2f(fn)),
+    "integer(c_int) :: d(2)",
+    fixed = TRUE
+  )
+  expect_translation_snapshots(fn)
+  expect_quick_identical(fn, list(m))
+})
+
+test_that("diag() initializes integer-backed logical outputs as integers", {
+  fn <- function(x) {
+    declare(type(x = logical(2)))
+    diag(x, 3L, 4L)
+  }
+
+  expect_match(as.character(r2f(fn)), "out_ = 0_c_int", fixed = TRUE)
+  expect_translation_snapshots(fn)
+  expect_quick_identical(fn, list(c(TRUE, FALSE)))
+})


### PR DESCRIPTION
> **Stacked PR 4 of 15** — branch `conformability/04-ifelse-t-diag`,
> cut from PR 3 (#139), branch `conformability/03-type-promotion`.
> GitHub can only diff a fork branch against `main`, so until PR 3 merges
> this page also shows PRs 1–3's commits; the 3 commits new to *this*
> PR are `Promote ifelse() branches and shape the result like test` …
> `Enforce the ifelse() branch-shape contract`.
>
> Stack overview and suggested review order: #152.

Fixes #125.

## What changed

Three handlers now match R's result types (and, for `ifelse()`, R's
result shape):

**`ifelse()` promotes its branches and shapes the result like `test`.**
Mixed-mode branches previously emitted an invalid mixed-type `merge()`
(Fortran requires same-typed branches), so this failed at the gfortran
stage:

```r
fn <- function(c, a) {
  declare(type(c = logical(n)), type(a = double(n)))
  ifelse(c, 1L, a)
}
# before: merge(1_c_int, a, (c/=0)) declared integer -> gfortran error
# after:  merge(real(1_c_int, kind=c_double), a, (c/=0)) declared double
```

The result's shape now comes from `test`, per R's documented contract,
instead of from the first non-scalar of `(test, yes, no)`. One case
becomes a compile-time error: a scalar `test` with array-valued
branches (R returns a length-1 result there, which `merge` cannot
express — previously this silently emitted a branch-shaped result):

```
Error: ifelse() result takes the shape of `test`; array-valued yes/no
with scalar test is not supported
```

**`ifelse()` enforces branch shapes.** Fortran's `merge()` requires
conformable arguments, so a runtime length mismatch between `test` and a
non-scalar branch read past the shorter branch and returned garbage
(`c(10, 2, 4.65e-310)` where R recycles). A non-scalar branch must now
match the shape of `test`: statically unequal dims (including rank
mismatches) are a compile error, and symbolic dims emit a statement-level
runtime size guard — the same three-valued policy the elementwise
operators adopt later in this series. `NA` dims always count as unknown
(two unknown lengths are not the same quantity). Scalar branches
broadcast natively, as before. R-style branch *recycling* is deliberately
not implemented — refusal keeps the "matches R or errors" invariant.

**`t()` and `diag()` preserve the input mode.** Both unconditionally
cast to double; R preserves the input's type:

```r
fn <- function(m) {
  declare(type(m = integer(2, 3)))
  t(m)
}
typeof(quick(fn)(matrix(1:6, 2, 3)))
# before: "double"   after: "integer" (matches R)
```

This covers `t(<matrix>)`, `t(<vector>)`, `diag(<matrix>)` (diagonal
extraction), and the constructor forms `diag(x)` / `diag(x, nrow, ncol)`
(R preserves `typeof(x)`: `diag(1:3)` is integer, `diag(TRUE, 2)` is
logical). The identity forms (`diag(n)`, `diag(nrow = n)`) stay double,
matching R.

Not changed, deliberately: the transposes feeding matrix products
(`%*%`, `crossprod`, ...) keep their double casts — R's matrix products
always return double — with a comment added saying why.

## How

- `R/r2f-conditionals.R`: the `ifelse` handler promotes both branches
  through `promote_operands()` (the helper introduced for operators and
  `c()`), takes dims from the booleanized mask, and errors on the
  scalar-test/array-branch case. Branch shapes are checked per axis
  (`ifelse_axis_verdict()`); unknown axes are guarded through
  `emit_quickr_error_if()`, combined into one `.or.` condition per
  branch.
- `R/r2f-matrix.R`, `R/r2f-matrix-blas.R`: `t()`, `diag_extract()`, and
  `diag_matrix()` drop their `maybe_cast_double()` and carry the input
  mode through the result `Variable`, hoisted temporaries, and
  `diag_matrix()`'s zero fill.
- `R/r2f-matrix-blas.R`: `can_use_output()` gains a `mode` argument
  (default `"double"`, all other callers unchanged) so an in-place
  destination is only used when its declared mode matches the result.
- `R/r2f-matrix-infer.R`: `infer_dest_diag()` reports the input's mode
  instead of hard-coding double, so `out <- diag(m)` declares `out`
  with the right mode on the inferred-destination path too. When the
  input's mode is not yet known it reports no destination rather than
  guessing one.
- `diag_matrix()`'s zero fill is spelled per mode (`0_c_int`, `.false.`,
  …) and refuses modes it cannot spell.

## Tests

- `test-ifelse.R`: mixed-mode branches compile and match R (including
  `typeof()`), logical branches join as logical, and the
  scalar-test/array-branch case raises the new error. A translation
  snapshot locks the promoted `merge` spelling. New shape tests: a
  statically mismatched branch is a compile error, unknown-length
  branches guard at runtime (conformable inputs still match R;
  mismatched inputs raise instead of returning garbage), with a
  snapshot pinning the guard text.
- `test-matrix.R`: `t()` and `diag()` preserve integer and logical
  modes across the matrix, vector, rectangular-with-recycling, and
  inferred-destination (`out <- diag(m)`) paths; the identity form
  stays double. A snapshot locks the integer `diag` extraction writing
  directly into the integer output.

No existing snapshots changed; the only snapshot additions are the two
new tests above.

## Notes for review

- Breaking behavior: `ifelse()` with scalar `test` and non-scalar
  branches now errors at compile time instead of returning a
  branch-shaped result (a silent divergence from R before).
- Breaking behavior: `ifelse()` with branch lengths that differ from
  `test` now errors (compile-time when static, runtime when symbolic)
  instead of recycling in R and reading out of bounds in quickr.
- Result `typeof()` changes (double → integer/logical) for `t()` and
  `diag()` on non-double inputs — previously a silent divergence from R.
- `diag()`'s constructor forms preserve `typeof(x)` in (at least
  reasonably modern) R — `typeof(diag(1:3))` is `"integer"` — so those
  are fixed here too, not just `diag(<matrix>)`.