### PR TITLE
[5/15] Validate subscripts and make in-loop errors cancel OpenMP loops

### DIFF
--- a/R/c-wrapper.R
+++ b/R/c-wrapper.R
@@ -459,6 +459,26 @@ c_bridge_hoist_take_pending <- function(hoist) {
   pending
 }
 
+c_bridge_hoist_seq_checks <- function(hoist, from, to, by) {
+  stopifnot(
+    is.environment(hoist),
+    is_string(from),
+    is_string(to),
+    is_string(by)
+  )
+  hoist$pending <- c(
+    hoist$pending,
+    glue(
+      '
+      if (({from} != {to}) && ({by} == 0))
+        Rf_error("invalid \'(to - from)/by\'");
+      if ((({from} < {to}) && ({by} < 0)) ||
+          (({from} > {to}) && ({by} > 0)))
+        Rf_error("wrong sign in \'by\' argument");'
+    )
+  )
+}
+
 
 as_c_name <- function(var, c_hoist = NULL) {
   stopifnot(inherits(var, Variable))
@@ -580,6 +600,23 @@ dims2c_expr <- function(e, scope, c_hoist = NULL) {
       stop("ncol() expects one argument")
     }
     return(dims2c_dim_index_expr(call("[", call("dim", args[[1L]]), 2L), scope))
+  }
+
+  if (identical(op, "quickr_seq_length")) {
+    if (length(args) != 3L || is.null(c_hoist)) {
+      stop("quickr_seq_length() requires three arguments and a C bridge hoist")
+    }
+    from <- dims2c_expr(args[[1L]], scope, c_hoist = c_hoist)
+    to <- dims2c_expr(args[[2L]], scope, c_hoist = c_hoist)
+    by <- dims2c_expr(args[[3L]], scope, c_hoist = c_hoist)
+    c_bridge_hoist_seq_checks(c_hoist, from, to, by)
+
+    safe_by <- glue("(({by}) == 0 ? 1 : ({by}))")
+    delta <- glue("((R_xlen_t)({to}) - (R_xlen_t)({from}))")
+    quotient <- glue("({delta} / (R_xlen_t)({safe_by}))")
+    return(glue(
+      "((({quotient}) < 0 ? -({quotient}) : ({quotient})) + 1)"
+    ))
   }
 
   if (identical(op, "abs")) {

--- a/R/declare.R
+++ b/R/declare.R
@@ -18,6 +18,15 @@
 #' and `OMP_DYNAMIC` (disable/enable runtime adjustment). Set them before
 #' calling a compiled function, e.g. `Sys.setenv(OMP_NUM_THREADS = "4")`.
 #'
+#' When an error is raised inside a parallel loop, quickr cancels the
+#' remaining iterations via OpenMP cancellation, which the OpenMP runtime
+#' only honors when `OMP_CANCELLATION=true` is set before the runtime first
+#' initializes in the process. quickr sets it when the package loads (unless
+#' already set), but this has no effect if another package initialized the
+#' OpenMP runtime first. Early exit is best-effort either way: the error
+#' message is always recorded correctly; without cancellation the remaining
+#' iterations simply run to completion before the error is raised.
+#'
 #' @param ... Declarations, typically calls like `type(x = double(n))`.
 #' @returns `NULL`, invisibly.
 #' @rawNamespace if (getRversion() < "4.4.0") export(declare)

--- a/R/error-handling.R
+++ b/R/error-handling.R
@@ -112,6 +112,32 @@ quickr_error_fortran_lines <- function(message = NULL, scope = NULL) {
   lines
 }
 
+# Emit a runtime guard: if `condition` holds, record a quickr error and
+# bail out of the subroutine (or cancel the OpenMP loop). Statement-level
+# machinery shared by any handler that needs a runtime check.
+emit_quickr_error_if <- function(
+  condition,
+  message,
+  hoist,
+  scope
+) {
+  stopifnot(
+    is_string(condition),
+    is_string(message),
+    inherits(hoist, "environment"),
+    inherits(scope, "quickr_scope")
+  )
+  mark_scope_uses_errors(scope)
+  err_lines <- quickr_error_fortran_lines(message, scope = scope)
+  hoist$emit(glue(
+    "
+    if ({condition}) then
+    {indent(str_flatten_lines(err_lines))}
+    end if
+    "
+  ))
+}
+
 quickr_error_return_if_set <- function(
   scope,
   openmp_depth = scope_openmp_depth(scope)

--- a/R/manifest.R
+++ b/R/manifest.R
@@ -522,6 +522,10 @@ dims2f_eval_base_env[["%%"]] <- function(e1, e2) {
 }
 dims2f_eval_base_env[["^"]] <- function(e1, e2) glue("({e1})**({e2})")
 dims2f_eval_base_env[["abs"]] <- function(x) glue("abs({x})")
+dims2f_eval_base_env[["quickr_seq_length"]] <- function(from, to, by) {
+  safe_by <- glue("merge(int({by}), 1, int({by}) /= 0)")
+  glue("(abs((int({to}) - int({from})) / {safe_by}) + 1)")
+}
 dims2f_eval_base_env[["length"]] <- function(x) {
   if (is.symbol(x)) {
     glue("size({as.character(x)})")

--- a/R/r2f-closures.R
+++ b/R/r2f-closures.R
@@ -1389,6 +1389,16 @@ compile_subset_designator <- function(
     is_bool(allow_logical_vector_subscripts)
   )
 
+  # Same validation as the read-side `[` handler: assignment subscripts
+  # would otherwise lower R's exclusion/zero/out-of-range subscripts into
+  # silent out-of-bounds Fortran writes.
+  extents <- subscript_axis_extents(base_var, length(idx_args))
+  for (i in seq_along(idx_args)) {
+    if (!is_missing(idx_args[[i]])) {
+      check_subscript_expr(idx_args[[i]], extent = extents[[i]])
+    }
+  }
+
   idxs <- whole_doubles_to_ints(idx_args)
   idxs <- imap(idxs, function(idx, i) {
     if (is_missing(idx)) {

--- a/R/r2f-closures.R
+++ b/R/r2f-closures.R
@@ -1392,12 +1392,7 @@ compile_subset_designator <- function(
   # Same validation as the read-side `[` handler: assignment subscripts
   # would otherwise lower R's exclusion/zero/out-of-range subscripts into
   # silent out-of-bounds Fortran writes.
-  extents <- subscript_axis_extents(base_var, length(idx_args))
-  for (i in seq_along(idx_args)) {
-    if (!is_missing(idx_args[[i]])) {
-      check_subscript_expr(idx_args[[i]], extent = extents[[i]])
-    }
-  }
+  check_subscript_exprs(base_var, idx_args)
 
   idxs <- whole_doubles_to_ints(idx_args)
   idxs <- imap(idxs, function(idx, i) {

--- a/R/r2f-control-flow.R
+++ b/R/r2f-control-flow.R
@@ -77,7 +77,7 @@ r2f_handlers[["while"]] <- function(args, scope, ...) {
 }
 
 # ---- for ----
-r2f_handlers[["for"]] <- function(args, scope, ...) {
+r2f_handlers[["for"]] <- function(args, scope, ..., hoist = NULL) {
   .[var, iterable, body] <- args
   stopifnot(is.symbol(var))
   var <- as.character(var)
@@ -174,7 +174,10 @@ r2f_handlers[["for"]] <- function(args, scope, ...) {
       previous_openmp <- enter_openmp_scope(scope)
       on.exit(exit_openmp_scope(scope, previous_openmp), add = TRUE)
     }
-    body <- r2f(body, scope, ...)
+    # The body is a distinct execution region and needs its own hoist target.
+    # Otherwise a single-expression body reuses the enclosing statement's
+    # target and emits loop-dependent setup before the loop.
+    body <- r2f(body, scope, ..., hoist = NULL)
     check_pending_parallel_consumed(scope)
     loop_stmts <- str_flatten_lines(glue("{var_name} = {element_expr}"), body)
 
@@ -214,12 +217,14 @@ r2f_handlers[["for"]] <- function(args, scope, ...) {
   }
   scope[[var]] <- loop_var
 
-  iterable <- r2f_for_iterable(iterable, scope, ...)
+  iterable <- r2f_for_iterable(iterable, scope, ..., hoist = hoist)
   if (!is.null(parallel)) {
     previous_openmp <- enter_openmp_scope(scope)
     on.exit(exit_openmp_scope(scope, previous_openmp), add = TRUE)
   }
-  body <- r2f(body, scope, ...)
+  # See the value-iteration path above: body-local setup must run inside the
+  # loop even when the R body is not wrapped in braces.
+  body <- r2f(body, scope, ..., hoist = NULL)
   check_pending_parallel_consumed(scope)
 
   directives <- openmp_directives(parallel)

--- a/R/r2f-iterables-helpers.R
+++ b/R/r2f-iterables-helpers.R
@@ -381,6 +381,10 @@ check_subscript_range_bounds <- function(info, from, to, by_f, hoist, scope) {
   from_lit <- lit(info$from)
   to_lit <- lit(info$to)
   by_lit <- if (is.null(info$by)) 1L else lit(info$by)
+  same_endpoint <- identical(
+    unwrap_parens(info$from),
+    unwrap_parens(info$to)
+  )
 
   bounds_msg <- "index ranges in x[a:b] must have bounds >= 1"
   if (isTRUE(from_lit < 1L) || isTRUE(to_lit < 1L)) {
@@ -416,15 +420,15 @@ check_subscript_range_bounds <- function(info, from, to, by_f, hoist, scope) {
     emit(paste(checks, collapse = " .or. "), bounds_msg)
   }
 
-  # Explicit seq() step. The result length divides by the step, and that
-  # length is evaluated in the C bridge *before* any Fortran guard can run
-  # (a zero step would be a division-by-zero crash there), so a non-literal
-  # step is a compile error, not a guard. With a literal step and symbolic
-  # bounds, R errors when the step's sign opposes the direction -- the
-  # emitted section would be zero-length while the claimed length is not;
-  # that case is checkable at runtime. All-literal ranges were already
-  # validated by seq_like_length_expr() at compile time.
-  if (!is.null(info$by)) {
+  # Explicit seq() step. When the endpoints differ, the result length divides
+  # by the step, and that length is evaluated in the C bridge *before* any
+  # Fortran guard can run (a zero step would be a division-by-zero crash
+  # there), so a non-literal step is a compile error, not a guard. With a
+  # literal step and symbolic bounds, R errors when the step's sign opposes
+  # the direction -- the emitted section would be zero-length while the
+  # claimed length is not; that case is checkable at runtime. All-literal
+  # ranges were already validated by seq_like_length_expr() at compile time.
+  if (!is.null(info$by) && !same_endpoint) {
     if (is.na(by_lit)) {
       stop(
         "seq() in x[...] requires a literal `by` step ",

--- a/R/r2f-iterables-helpers.R
+++ b/R/r2f-iterables-helpers.R
@@ -334,9 +334,8 @@ seq_like_r2f <- function(
       glue("{start}, {end}, {step}")
     }
   } else if (context == "[") {
-    # `:`/`seq` sections are only correct for bounds >= 1 (and a step whose
-    # sign matches); seq_len/seq_along need no check -- their worst case is
-    # a legal zero-length section, which matches R's x[integer(0)].
+    # Validate statically-known unsupported bounds and seq() step semantics.
+    # Dynamically computed array bounds remain the caller's responsibility.
     if (kind %in% c(":", "seq")) {
       check_subscript_range_bounds(
         info,
@@ -364,14 +363,11 @@ seq_like_r2f <- function(
   Fortran(fr, val)
 }
 
-# Validate an x[a:b] / x[seq(a, b, by)] index range.
-# In subscript context the emitted section `from:to:sign(1, to-from)` and its
-# claimed length `abs(to - from) + 1` are only correct when both bounds are
-# >= 1: R's x[1:0] drops the 0 (a value-dependent shape quickr cannot
-# produce), and the sign-stride section would read x(0). Statically-bad
-# literal bounds are compile errors; unknown bounds get a statement-level
-# runtime check via emit_quickr_error_if(). An explicit seq() step is
-# handled below (literal-only, plus a runtime wrong-sign check).
+# Validate an x[a:b] / x[seq(a, b, by)] index range where doing so has no
+# general bounds-checking cost. Statically bad literal bounds are compile
+# errors. Dynamic bounds are trusted, consistently with symbolic scalar and
+# vector subscripts. An explicit seq() step is handled below (literal-only,
+# plus a runtime wrong-sign check required by seq() semantics).
 # Used by: seq_like_r2f() (subscript context)
 check_subscript_range_bounds <- function(info, from, to, by_f, hoist, scope) {
   lit <- function(e) {
@@ -407,17 +403,6 @@ check_subscript_range_bounds <- function(info, from, to, by_f, hoist, scope) {
       )
     }
     emit_quickr_error_if(condition, message, hoist, scope)
-  }
-
-  checks <- character()
-  if (is.na(from_lit)) {
-    checks <- c(checks, glue("{from} < 1_c_int"))
-  }
-  if (is.na(to_lit)) {
-    checks <- c(checks, glue("{to} < 1_c_int"))
-  }
-  if (length(checks)) {
-    emit(paste(checks, collapse = " .or. "), bounds_msg)
   }
 
   # Explicit seq() step. When the endpoints differ, the result length divides

--- a/R/r2f-iterables-helpers.R
+++ b/R/r2f-iterables-helpers.R
@@ -46,7 +46,11 @@ seq_like_length_expr <- function(from, to, by = NULL) {
     return(1L)
   }
 
-  if (is_scalar_integerish(from) && is_scalar_integerish(to)) {
+  if (
+    is_scalar_integerish(from) &&
+      is_scalar_integerish(to) &&
+      (is.null(by) || is_scalar_integerish(by)) # symbolic by: length needs it
+  ) {
     from_val <- as.integer(from)
     to_val <- as.integer(to)
     delta <- to_val - from_val
@@ -280,6 +284,19 @@ seq_like_r2f <- function(
       glue("{start}, {end}, {step}")
     }
   } else if (context == "[") {
+    # `:`/`seq` sections are only correct for bounds >= 1 (and a step whose
+    # sign matches); seq_len/seq_along need no check -- their worst case is
+    # a legal zero-length section, which matches R's x[integer(0)].
+    if (kind %in% c(":", "seq")) {
+      check_subscript_range_bounds(
+        info,
+        from,
+        to,
+        by_f = by,
+        hoist = list(...)$hoist,
+        scope = scope
+      )
+    }
     fr <- if (omit_step) {
       glue("{start}:{end}")
     } else {
@@ -295,6 +312,86 @@ seq_like_r2f <- function(
   }
 
   Fortran(fr, val)
+}
+
+# Validate an x[a:b] / x[seq(a, b, by)] index range.
+# In subscript context the emitted section `from:to:sign(1, to-from)` and its
+# claimed length `abs(to - from) + 1` are only correct when both bounds are
+# >= 1: R's x[1:0] drops the 0 (a value-dependent shape quickr cannot
+# produce), and the sign-stride section would read x(0). Statically-bad
+# literal bounds are compile errors; unknown bounds get a statement-level
+# runtime check via emit_quickr_error_if(). An explicit seq() step is
+# handled below (literal-only, plus a runtime wrong-sign check).
+# Used by: seq_like_r2f() (subscript context)
+check_subscript_range_bounds <- function(info, from, to, by_f, hoist, scope) {
+  lit <- function(e) {
+    if (is_wholenumber(e)) as.integer(e) else NA_integer_
+  }
+  from_lit <- lit(info$from)
+  to_lit <- lit(info$to)
+  by_lit <- if (is.null(info$by)) 1L else lit(info$by)
+
+  bounds_msg <- "index ranges in x[a:b] must have bounds >= 1"
+  if (isTRUE(from_lit < 1L) || isTRUE(to_lit < 1L)) {
+    stop(
+      bounds_msg,
+      ": ",
+      deparse1(info$from),
+      ", ",
+      deparse1(info$to),
+      call. = FALSE
+    )
+  }
+
+  emit <- function(condition, message) {
+    if (is.null(hoist)) {
+      stop(
+        "cannot emit a runtime subscript-range guard here; ",
+        "use literal bounds >= 1 in x[a:b]",
+        call. = FALSE
+      )
+    }
+    emit_quickr_error_if(condition, message, hoist, scope)
+  }
+
+  checks <- character()
+  if (is.na(from_lit)) {
+    checks <- c(checks, glue("{from} < 1_c_int"))
+  }
+  if (is.na(to_lit)) {
+    checks <- c(checks, glue("{to} < 1_c_int"))
+  }
+  if (length(checks)) {
+    emit(paste(checks, collapse = " .or. "), bounds_msg)
+  }
+
+  # Explicit seq() step. The result length divides by the step, and that
+  # length is evaluated in the C bridge *before* any Fortran guard can run
+  # (a zero step would be a division-by-zero crash there), so a non-literal
+  # step is a compile error, not a guard. With a literal step and symbolic
+  # bounds, R errors when the step's sign opposes the direction -- the
+  # emitted section would be zero-length while the claimed length is not;
+  # that case is checkable at runtime. All-literal ranges were already
+  # validated by seq_like_length_expr() at compile time.
+  if (!is.null(info$by)) {
+    if (is.na(by_lit)) {
+      stop(
+        "seq() in x[...] requires a literal `by` step ",
+        "(the result length depends on it): by = ",
+        deparse1(info$by),
+        call. = FALSE
+      )
+    }
+    if (is.na(from_lit) || is.na(to_lit)) {
+      emit(
+        glue(
+          "(({to} /= {from}) .and. (sign(1_c_int, {by_f}) /= sign(1_c_int, {to} - {from})))"
+        ),
+        "wrong sign in 'by' argument in x[seq(a, b, by)]"
+      )
+    }
+  }
+  invisible(NULL)
 }
 
 # Unwrap a for-loop iterable, handling rev() calls.

--- a/R/r2f-iterables-helpers.R
+++ b/R/r2f-iterables-helpers.R
@@ -76,7 +76,39 @@ seq_like_length_expr <- function(from, to, by = NULL) {
   if (is.null(by)) {
     return(call("+", call("abs", call("-", to, from)), 1L))
   }
-  call("+", call("abs", call("%/%", call("-", to, from), by)), 1L)
+  call("quickr_seq_length", from, to, by)
+}
+
+seq_like_step_needs_runtime_check <- function(info) {
+  !is.null(info$by) &&
+    !(is_scalar_integerish(info$from) &&
+      is_scalar_integerish(info$to) &&
+      is_scalar_integerish(info$by))
+}
+
+emit_seq_step_runtime_checks <- function(from, to, by, hoist, scope) {
+  stopifnot(
+    inherits(from, Fortran),
+    inherits(to, Fortran),
+    inherits(by, Fortran),
+    inherits(hoist, "environment"),
+    inherits(scope, "quickr_scope")
+  )
+  emit_quickr_error_if(
+    glue("({from} /= {to}) .and. ({by} == 0_c_int)"),
+    "invalid '(to - from)/by'",
+    hoist,
+    scope
+  )
+  emit_quickr_error_if(
+    glue(
+      "(({to} > {from}) .and. ({by} < 0_c_int)) .or. ",
+      "(({to} < {from}) .and. ({by} > 0_c_int))"
+    ),
+    "wrong sign in 'by' argument",
+    hoist,
+    scope
+  )
 }
 
 # Parse a seq-like call into its components.
@@ -251,6 +283,24 @@ seq_like_r2f <- function(
   context <- context %||% r2f_iterable_context(list(...)$calls)
   if (is.null(context)) {
     context <- "value"
+  }
+
+  check_step_at_runtime <- kind == "seq" &&
+    seq_like_step_needs_runtime_check(info)
+  if (check_step_at_runtime && context != "[") {
+    emit_seq_step_runtime_checks(
+      from,
+      to,
+      by,
+      hoist = list(...)$hoist,
+      scope = scope
+    )
+  }
+  if (check_step_at_runtime) {
+    by <- Fortran(
+      glue("merge(int({by}, kind=c_int), 1_c_int, {from} /= {to})"),
+      Variable("integer")
+    )
   }
 
   if (is.null(len_expr) || is_scalar_na(len_expr)) {

--- a/R/r2f-iterables-helpers.R
+++ b/R/r2f-iterables-helpers.R
@@ -375,7 +375,8 @@ seq_like_r2f <- function(
 # Used by: seq_like_r2f() (subscript context)
 check_subscript_range_bounds <- function(info, from, to, by_f, hoist, scope) {
   lit <- function(e) {
-    if (is_wholenumber(e)) as.integer(e) else NA_integer_
+    e <- unwrap_parens(e)
+    if (is_scalar_integerish(e)) as.integer(e) else NA_integer_
   }
   from_lit <- lit(info$from)
   to_lit <- lit(info$to)

--- a/R/r2f-matrix-blas.R
+++ b/R/r2f-matrix-blas.R
@@ -74,29 +74,6 @@ assert_conformable_dims <- function(left, right, context, err_msg) {
   invisible(TRUE)
 }
 
-emit_quickr_error_if <- function(
-  condition,
-  message,
-  hoist,
-  scope
-) {
-  stopifnot(
-    is_string(condition),
-    is_string(message),
-    inherits(hoist, "environment"),
-    inherits(scope, "quickr_scope")
-  )
-  mark_scope_uses_errors(scope)
-  err_lines <- quickr_error_fortran_lines(message, scope = scope)
-  hoist$emit(glue(
-    "
-    if ({condition}) then
-    {indent(str_flatten_lines(err_lines))}
-    end if
-    "
-  ))
-}
-
 # Return the R symbol name if operand is a bare symbol; otherwise NULL.
 symbol_name_or_null <- function(x) {
   stopifnot(inherits(x, Fortran))

--- a/R/r2f-subscript.R
+++ b/R/r2f-subscript.R
@@ -23,12 +23,7 @@ r2f_handlers[["["]] <- function(
   drop <- idx_args$drop %||% TRUE
   idx_args$drop <- NULL
 
-  extents <- subscript_axis_extents(var@value, length(idx_args))
-  for (i in seq_along(idx_args)) {
-    if (!is_missing(idx_args[[i]])) {
-      check_subscript_expr(idx_args[[i]], extent = extents[[i]])
-    }
-  }
+  check_subscript_exprs(var@value, idx_args)
 
   idxs <- whole_doubles_to_ints(idx_args)
   idxs <- imap(idxs, function(idx, i) {
@@ -306,11 +301,24 @@ check_subscript_expr <- function(e, extent = NULL) {
   invisible(NULL)
 }
 
+# Validate every non-missing subscript in `idx_args` against `base_var`'s
+# statically known extents. The single entry point for both the read side
+# (the `[` handler) and the write side (compile_subset_designator() in
+# r2f-closures.R), so read and write subscripts validate identically.
+check_subscript_exprs <- function(base_var, idx_args) {
+  extents <- subscript_axis_extents(base_var, length(idx_args))
+  for (i in seq_along(idx_args)) {
+    if (!is_missing(idx_args[[i]])) {
+      check_subscript_expr(idx_args[[i]], extent = extents[[i]])
+    }
+  }
+  invisible(NULL)
+}
+
 # Statically-known extent per subscript axis; NULL where symbolic/unknown.
 # A single subscript on a rank>1 base is R's linear indexing -- its extent
 # is the product of the dims when all of them are known.
-# Used by: the `[` handler (above) and compile_subset_designator()
-# (r2f-closures.R), so read and write subscripts validate identically.
+# Used by: check_subscript_exprs()
 subscript_axis_extents <- function(var, n_idx) {
   dims <- var@dims
   if (n_idx == length(dims)) {

--- a/R/r2f-subscript.R
+++ b/R/r2f-subscript.R
@@ -242,9 +242,9 @@ r2f_handlers[["["]] <- function(
 # reads with NA and grows the vector on out-of-range writes -- neither
 # representable in quickr's static-shape model -- while the generated
 # Fortran would silently read or write out of bounds. Literal `:` range
-# endpoints are checked against the extent here too; their >= 1 lower-bound
-# validation (including the runtime guard for symbolic endpoints) stays in
-# check_subscript_range_bounds().
+# endpoints are checked against the extent here too; literal lower-bound and
+# seq() step validation stays in check_subscript_range_bounds(). Dynamic
+# subscript bounds remain the caller's responsibility.
 check_subscript_expr <- function(e, extent = NULL) {
   e <- unwrap_parens(e)
   while (is_call(e, quote(`-`)) && length(e) == 2L) {

--- a/R/r2f-subscript.R
+++ b/R/r2f-subscript.R
@@ -23,9 +23,10 @@ r2f_handlers[["["]] <- function(
   drop <- idx_args$drop %||% TRUE
   idx_args$drop <- NULL
 
-  for (idx in idx_args) {
-    if (!is_missing(idx)) {
-      check_subscript_expr(idx)
+  extents <- subscript_axis_extents(var@value, length(idx_args))
+  for (i in seq_along(idx_args)) {
+    if (!is_missing(idx_args[[i]])) {
+      check_subscript_expr(idx_args[[i]], extent = extents[[i]])
     }
   }
 
@@ -239,15 +240,40 @@ r2f_handlers[["["]] <- function(
 # Fortran would silently read out of bounds. Unary minus on a subscript is
 # unambiguously exclusion syntax in R, so the form is rejected, not just
 # statically-known values. Binary minus (x[n - 1]) is untouched.
-check_subscript_expr <- function(e) {
+#
+# When the base's extent along the subscript's axis is statically known,
+# literal values beyond it are also compile errors: R pads out-of-range
+# reads with NA and grows the vector on out-of-range writes -- neither
+# representable in quickr's static-shape model -- while the generated
+# Fortran would silently read or write out of bounds. Literal `:` range
+# endpoints are checked against the extent here too; their >= 1 lower-bound
+# validation (including the runtime guard for symbolic endpoints) stays in
+# check_subscript_range_bounds().
+check_subscript_expr <- function(e, extent = NULL) {
   e <- unwrap_parens(e)
-  if (is.numeric(e) && length(e) >= 1L && !anyNA(e) && any(e <= 0)) {
-    stop(
-      "subscripts must be positive; R's negative (exclusion) and zero ",
-      "subscripts are not supported: ",
-      deparse1(e),
-      call. = FALSE
-    )
+  if (!is_wholenumber(extent)) {
+    extent <- NULL
+  }
+  if (is.numeric(e) && length(e) >= 1L && !anyNA(e)) {
+    if (any(e <= 0)) {
+      stop(
+        "subscripts must be positive; R's negative (exclusion) and zero ",
+        "subscripts are not supported: ",
+        deparse1(e),
+        call. = FALSE
+      )
+    }
+    if (!is.null(extent) && any(e > extent)) {
+      stop(
+        "subscript exceeds its dimension's extent (",
+        as.integer(extent),
+        "): ",
+        deparse1(e),
+        "; R's out-of-range subscripts (NA padding, vector growing) ",
+        "are not supported",
+        call. = FALSE
+      )
+    }
   }
   if (is_call(e, quote(`-`)) && length(e) == 2L) {
     stop(
@@ -256,10 +282,48 @@ check_subscript_expr <- function(e) {
       call. = FALSE
     )
   }
+  if (is_call(e, quote(`:`)) && length(e) == 3L && !is.null(extent)) {
+    for (endpoint in as.list(e)[-1L]) {
+      endpoint <- unwrap_parens(endpoint)
+      if (is_wholenumber(endpoint) && endpoint > extent) {
+        stop(
+          "index range in x[a:b] exceeds its dimension's extent (",
+          as.integer(extent),
+          "): ",
+          deparse1(e),
+          "; R's out-of-range subscripts (NA padding, vector growing) ",
+          "are not supported",
+          call. = FALSE
+        )
+      }
+    }
+  }
   if (is_call(e, quote(c))) {
     for (arg in as.list(e)[-1L]) {
-      check_subscript_expr(arg)
+      check_subscript_expr(arg, extent = extent)
     }
   }
   invisible(NULL)
+}
+
+# Statically-known extent per subscript axis; NULL where symbolic/unknown.
+# A single subscript on a rank>1 base is R's linear indexing -- its extent
+# is the product of the dims when all of them are known.
+# Used by: the `[` handler (above) and compile_subset_designator()
+# (r2f-closures.R), so read and write subscripts validate identically.
+subscript_axis_extents <- function(var, n_idx) {
+  dims <- var@dims
+  if (n_idx == length(dims)) {
+    return(lapply(dims, function(d) {
+      if (is_wholenumber(d)) as.integer(d) else NULL
+    }))
+  }
+  if (
+    n_idx == 1L &&
+      length(dims) > 1L &&
+      all(vapply(dims, is_wholenumber, logical(1)))
+  ) {
+    return(list(prod(unlist(dims))))
+  }
+  rep(list(NULL), n_idx)
 }

--- a/R/r2f-subscript.R
+++ b/R/r2f-subscript.R
@@ -232,9 +232,10 @@ r2f_handlers[["["]] <- function(
 # Reject non-positive subscripts at compile time. R's negative subscript
 # means exclusion, so the result's shape depends on the subscript's value --
 # not representable in quickr's static-shape model -- while the generated
-# Fortran would silently read out of bounds. Unary minus on a subscript is
-# unambiguously exclusion syntax in R, so the form is rejected, not just
-# statically-known values. Binary minus (x[n - 1]) is untouched.
+# Fortran would silently read out of bounds. After cancelling paired unary
+# minuses, unary minus on a subscript is exclusion syntax in R, so the form is
+# rejected, not just statically-known values. Binary minus (x[n - 1]) is
+# untouched.
 #
 # When the base's extent along the subscript's axis is statically known,
 # literal values beyond it are also compile errors: R pads out-of-range
@@ -246,6 +247,23 @@ r2f_handlers[["["]] <- function(
 # check_subscript_range_bounds().
 check_subscript_expr <- function(e, extent = NULL) {
   e <- unwrap_parens(e)
+  while (is_call(e, quote(`-`)) && length(e) == 2L) {
+    inner <- unwrap_parens(e[[2L]])
+    if (
+      is.numeric(inner) &&
+        length(inner) == 1L &&
+        !is.na(inner) &&
+        is.finite(inner) &&
+        inner < 0
+    ) {
+      e <- -inner
+      next
+    }
+    if (!is_call(inner, quote(`-`)) || length(inner) != 2L) {
+      break
+    }
+    e <- unwrap_parens(inner[[2L]])
+  }
   if (!is_wholenumber(extent)) {
     extent <- NULL
   }

--- a/R/r2f-subscript.R
+++ b/R/r2f-subscript.R
@@ -250,7 +250,10 @@ check_subscript_expr <- function(e, extent = NULL) {
     extent <- NULL
   }
   if (is.numeric(e) && length(e) >= 1L && !anyNA(e)) {
-    if (any(e <= 0)) {
+    # R truncates numeric subscripts toward zero; match the int() conversion
+    # used by the generated Fortran before validating the resulting indices.
+    indices <- trunc(e)
+    if (any(indices <= 0)) {
       stop(
         "subscripts must be positive; R's negative (exclusion) and zero ",
         "subscripts are not supported: ",
@@ -258,7 +261,7 @@ check_subscript_expr <- function(e, extent = NULL) {
         call. = FALSE
       )
     }
-    if (!is.null(extent) && any(e > extent)) {
+    if (!is.null(extent) && any(indices > extent)) {
       stop(
         "subscript exceeds its dimension's extent (",
         as.integer(extent),

--- a/R/r2f-subscript.R
+++ b/R/r2f-subscript.R
@@ -23,6 +23,12 @@ r2f_handlers[["["]] <- function(
   drop <- idx_args$drop %||% TRUE
   idx_args$drop <- NULL
 
+  for (idx in idx_args) {
+    if (!is_missing(idx)) {
+      check_subscript_expr(idx)
+    }
+  }
+
   idxs <- whole_doubles_to_ints(idx_args)
   idxs <- imap(idxs, function(idx, i) {
     if (is_missing(idx)) {
@@ -225,4 +231,35 @@ r2f_handlers[["["]] <- function(
     base_name <- var@value@name %||% stop("missing array name for subscripting")
     Fortran(glue("{base_name}({str_flatten_commas(idxs)})"), outval)
   }
+}
+
+# Reject non-positive subscripts at compile time. R's negative subscript
+# means exclusion, so the result's shape depends on the subscript's value --
+# not representable in quickr's static-shape model -- while the generated
+# Fortran would silently read out of bounds. Unary minus on a subscript is
+# unambiguously exclusion syntax in R, so the form is rejected, not just
+# statically-known values. Binary minus (x[n - 1]) is untouched.
+check_subscript_expr <- function(e) {
+  e <- unwrap_parens(e)
+  if (is.numeric(e) && length(e) >= 1L && !anyNA(e) && any(e <= 0)) {
+    stop(
+      "subscripts must be positive; R's negative (exclusion) and zero ",
+      "subscripts are not supported: ",
+      deparse1(e),
+      call. = FALSE
+    )
+  }
+  if (is_call(e, quote(`-`)) && length(e) == 2L) {
+    stop(
+      "negative subscripts (exclusion) are not supported: ",
+      deparse1(e),
+      call. = FALSE
+    )
+  }
+  if (is_call(e, quote(c))) {
+    for (arg in as.list(e)[-1L]) {
+      check_subscript_expr(arg)
+    }
+  }
+  invisible(NULL)
 }

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -33,5 +33,14 @@
     S7::methods_register()
     asNamespace("dotty")$dotify()
   })
+  # Generated error paths inside OpenMP loops emit `!$omp cancel do`, which
+  # the OpenMP runtime treats as a no-op unless the cancel-var ICV is true.
+  # The ICV is read from OMP_CANCELLATION when the runtime first initializes
+  # in the process, so set it as early as quickr can; this has no effect if
+  # another package already started the OpenMP runtime. Error *messages* are
+  # recorded correctly either way -- cancellation only enables early exit.
+  if (!nzchar(Sys.getenv("OMP_CANCELLATION"))) {
+    Sys.setenv(OMP_CANCELLATION = "true")
+  }
   # on_load_register_.AtNames.default()
 }

--- a/man/declare.Rd
+++ b/man/declare.Rd
@@ -31,5 +31,14 @@ Control the number of OpenMP threads using environment variables such as
 \code{OMP_NUM_THREADS} (threads per region), \code{OMP_THREAD_LIMIT} (global cap),
 and \code{OMP_DYNAMIC} (disable/enable runtime adjustment). Set them before
 calling a compiled function, e.g. \code{Sys.setenv(OMP_NUM_THREADS = "4")}.
+
+When an error is raised inside a parallel loop, quickr cancels the
+remaining iterations via OpenMP cancellation, which the OpenMP runtime
+only honors when \code{OMP_CANCELLATION=true} is set before the runtime first
+initializes in the process. quickr sets it when the package loads (unless
+already set), but this has no effect if another package initialized the
+OpenMP runtime first. Early exit is best-effort either way: the error
+message is always recorded correctly; without cancellation the remaining
+iterations simply run to completion before the error is raised.
 }
 \keyword{internal}

--- a/tests/testthat/_snaps/example-roll_mean.md
+++ b/tests/testthat/_snaps/example-roll_mean.md
@@ -24,14 +24,17 @@
     Code
       cat(fsub)
     Output
-      subroutine fn(x, weights, normalize, out, weights__len_, x__len_) bind(c)
-        use iso_c_binding, only: c_double, c_int, c_ptrdiff_t
+      subroutine fn(x, weights, normalize, out, weights__len_, x__len_, quickr_err_msg) bind(c)
+        use iso_c_binding, only: c_char, c_double, c_int, c_null_char, c_ptrdiff_t
         implicit none
       
         ! manifest start
         ! sizes
         integer(c_ptrdiff_t), intent(in), value :: x__len_
         integer(c_ptrdiff_t), intent(in), value :: weights__len_
+      
+        ! error
+        character(kind=c_char), intent(inout) :: quickr_err_msg(256)
       
         ! args
         real(c_double), intent(in) :: x(x__len_)
@@ -51,8 +54,24 @@
           weights = ((weights / sum(weights)) * size(weights))
         end if
         do i = 1, size(out)
+          if (i < 1_c_int .or. (((i + n) - 1_c_int)) < 1_c_int) then
+            call quickr_set_error_msg("index ranges in x[a:b] must have bounds >= 1")
+            return
+          end if
           out(i) = (sum((x(i:(((i + n) - 1_c_int)):sign(1, (((i + n) - 1_c_int))-i)) * weights)) / real(size(weights), kind=c_double))
         end do
+      
+        contains
+          subroutine quickr_set_error_msg(msg)
+            character(len=*), intent(in) :: msg
+            integer :: i
+            integer :: n
+            if (quickr_err_msg(1) == c_null_char) then
+              n = min(len(msg), 256 - 1)
+              quickr_err_msg(1:n) = [(msg(i:i), i = 1, n)]
+              quickr_err_msg(n + 1) = c_null_char
+            end if
+          end subroutine quickr_set_error_msg
       end subroutine
     Code
       cat(cwrapper)
@@ -68,7 +87,8 @@
         const int* const normalize__, 
         double* const out__, 
         const R_xlen_t weights__len_, 
-        const R_xlen_t x__len_);
+        const R_xlen_t x__len_, 
+        char* quickr_err_msg);
       
       SEXP fn_(SEXP _args) {
         // x
@@ -107,13 +127,21 @@
         SEXP out = PROTECT(Rf_allocVector(REALSXP, out__len_));
         double* out__ = REAL(out);
         
+        char quickr_err_msg[256];
+        quickr_err_msg[0] = '\0';
+        
+        
         fn(
           x__,
           weights__,
           normalize__,
           out__,
           weights__len_,
-          x__len_);
+          x__len_,
+          quickr_err_msg);
+        if (quickr_err_msg[0] != '\0') {
+          Rf_error("%s", quickr_err_msg);
+        }
         
         UNPROTECT(1);
         return out;

--- a/tests/testthat/_snaps/example-roll_mean.md
+++ b/tests/testthat/_snaps/example-roll_mean.md
@@ -24,17 +24,14 @@
     Code
       cat(fsub)
     Output
-      subroutine fn(x, weights, normalize, out, weights__len_, x__len_, quickr_err_msg) bind(c)
-        use iso_c_binding, only: c_char, c_double, c_int, c_null_char, c_ptrdiff_t
+      subroutine fn(x, weights, normalize, out, weights__len_, x__len_) bind(c)
+        use iso_c_binding, only: c_double, c_int, c_ptrdiff_t
         implicit none
       
         ! manifest start
         ! sizes
         integer(c_ptrdiff_t), intent(in), value :: x__len_
         integer(c_ptrdiff_t), intent(in), value :: weights__len_
-      
-        ! error
-        character(kind=c_char), intent(inout) :: quickr_err_msg(256)
       
         ! args
         real(c_double), intent(in) :: x(x__len_)
@@ -54,24 +51,8 @@
           weights = ((weights / sum(weights)) * size(weights))
         end if
         do i = 1, size(out)
-          if (i < 1_c_int .or. (((i + n) - 1_c_int)) < 1_c_int) then
-            call quickr_set_error_msg("index ranges in x[a:b] must have bounds >= 1")
-            return
-          end if
           out(i) = (sum((x(i:(((i + n) - 1_c_int)):sign(1, (((i + n) - 1_c_int))-i)) * weights)) / real(size(weights), kind=c_double))
         end do
-      
-        contains
-          subroutine quickr_set_error_msg(msg)
-            character(len=*), intent(in) :: msg
-            integer :: i
-            integer :: n
-            if (quickr_err_msg(1) == c_null_char) then
-              n = min(len(msg), 256 - 1)
-              quickr_err_msg(1:n) = [(msg(i:i), i = 1, n)]
-              quickr_err_msg(n + 1) = c_null_char
-            end if
-          end subroutine quickr_set_error_msg
       end subroutine
     Code
       cat(cwrapper)
@@ -87,8 +68,7 @@
         const int* const normalize__, 
         double* const out__, 
         const R_xlen_t weights__len_, 
-        const R_xlen_t x__len_, 
-        char* quickr_err_msg);
+        const R_xlen_t x__len_);
       
       SEXP fn_(SEXP _args) {
         // x
@@ -127,21 +107,13 @@
         SEXP out = PROTECT(Rf_allocVector(REALSXP, out__len_));
         double* out__ = REAL(out);
         
-        char quickr_err_msg[256];
-        quickr_err_msg[0] = '\0';
-        
-        
         fn(
           x__,
           weights__,
           normalize__,
           out__,
           weights__len_,
-          x__len_,
-          quickr_err_msg);
-        if (quickr_err_msg[0] != '\0') {
-          Rf_error("%s", quickr_err_msg);
-        }
+          x__len_);
         
         UNPROTECT(1);
         return out;

--- a/tests/testthat/_snaps/subscript-validation.md
+++ b/tests/testthat/_snaps/subscript-validation.md
@@ -1,0 +1,168 @@
+# x[a:b] guards against non-positive bounds at runtime
+
+    Code
+      fn
+    Output
+      function(x, n) {
+          declare(type(x = double(NA)), type(n = integer(1)))
+          x[1:n]
+        }
+      <environment: 0x0>
+    Code
+      cat(fsub)
+    Output
+      subroutine fn(x, n, out_, x__len_, quickr_err_msg) bind(c)
+        use iso_c_binding, only: c_char, c_double, c_int, c_null_char, c_ptrdiff_t
+        implicit none
+      
+        ! manifest start
+        ! sizes
+        integer(c_ptrdiff_t), intent(in), value :: x__len_
+      
+        ! error
+        character(kind=c_char), intent(inout) :: quickr_err_msg(256)
+      
+        ! args
+        real(c_double), intent(in) :: x(x__len_)
+        integer(c_int), intent(in) :: n
+        real(c_double), intent(out) :: out_((abs((n - 1)) + 1))
+        ! manifest end
+      
+      
+        if (n < 1_c_int) then
+          call quickr_set_error_msg("index ranges in x[a:b] must have bounds >= 1")
+          return
+        end if
+        out_ = x(1_c_int:n:sign(1, n-1_c_int))
+      
+        contains
+          subroutine quickr_set_error_msg(msg)
+            character(len=*), intent(in) :: msg
+            integer :: i
+            integer :: n
+            if (quickr_err_msg(1) == c_null_char) then
+              n = min(len(msg), 256 - 1)
+              quickr_err_msg(1:n) = [(msg(i:i), i = 1, n)]
+              quickr_err_msg(n + 1) = c_null_char
+            end if
+          end subroutine quickr_set_error_msg
+      end subroutine
+    Code
+      cat(cwrapper)
+    Output
+      #define R_NO_REMAP
+      #include <R.h>
+      #include <Rinternals.h>
+      
+      
+      extern void fn(
+        const double* const x__, 
+        const int* const n__, 
+        double* const out___, 
+        const R_xlen_t x__len_, 
+        char* quickr_err_msg);
+      
+      SEXP fn_(SEXP _args) {
+        // x
+        _args = CDR(_args);
+        SEXP x = CAR(_args);
+        if (TYPEOF(x) != REALSXP) {
+          Rf_error("typeof(x) must be 'double', not '%s'", Rf_type2char(TYPEOF(x)));
+        }
+        const double* const x__ = REAL(x);
+        const R_xlen_t x__len_ = Rf_xlength(x);
+        
+        // n
+        _args = CDR(_args);
+        SEXP n = CAR(_args);
+        if (TYPEOF(n) != INTSXP) {
+          Rf_error("typeof(n) must be 'integer', not '%s'", Rf_type2char(TYPEOF(n)));
+        }
+        const int* const n__ = INTEGER(n);
+        const R_xlen_t n__len_ = Rf_xlength(n);
+        
+        if (n__len_ != 1)
+          Rf_error("length(n) must be 1, not %0.f",
+                    (double)n__len_);
+        const int _as_int_n = Rf_asInteger(n);
+        const R_xlen_t out___len_ = ((((_as_int_n - 1)) < 0 ? -((_as_int_n - 1)) : ((_as_int_n - 1))) + 1);
+        SEXP out_ = PROTECT(Rf_allocVector(REALSXP, out___len_));
+        double* out___ = REAL(out_);
+        
+        char quickr_err_msg[256];
+        quickr_err_msg[0] = '\0';
+        
+        
+        fn(
+          x__,
+          n__,
+          out___,
+          x__len_,
+          quickr_err_msg);
+        if (quickr_err_msg[0] != '\0') {
+          Rf_error("%s", quickr_err_msg);
+        }
+        
+        UNPROTECT(1);
+        return out_;
+      }
+
+# literal in-range bounds emit no guard; bad literals error at compile time
+
+    Code
+      fn
+    Output
+      function(x) {
+          declare(type(x = double(5)))
+          x[2:4]
+        }
+      <environment: 0x0>
+    Code
+      cat(fsub)
+    Output
+      subroutine fn(x, out_) bind(c)
+        use iso_c_binding, only: c_double, c_int
+        implicit none
+      
+        ! manifest start
+        ! args
+        real(c_double), intent(in) :: x(5)
+        real(c_double), intent(out) :: out_(3)
+        ! manifest end
+      
+      
+        out_ = x(2_c_int:4_c_int:sign(1, 4_c_int-2_c_int))
+      end subroutine
+    Code
+      cat(cwrapper)
+    Output
+      #define R_NO_REMAP
+      #include <R.h>
+      #include <Rinternals.h>
+      
+      
+      extern void fn(const double* const x__, double* const out___);
+      
+      SEXP fn_(SEXP _args) {
+        // x
+        _args = CDR(_args);
+        SEXP x = CAR(_args);
+        if (TYPEOF(x) != REALSXP) {
+          Rf_error("typeof(x) must be 'double', not '%s'", Rf_type2char(TYPEOF(x)));
+        }
+        const double* const x__ = REAL(x);
+        const R_xlen_t x__len_ = Rf_xlength(x);
+        
+        if (x__len_ != 5)
+          Rf_error("length(x) must be 5, not %0.f",
+                    (double)x__len_);
+        const R_xlen_t out___len_ = 3;
+        SEXP out_ = PROTECT(Rf_allocVector(REALSXP, out___len_));
+        double* out___ = REAL(out_);
+        
+        fn(x__, out___);
+        
+        UNPROTECT(1);
+        return out_;
+      }
+

--- a/tests/testthat/_snaps/subscript-validation.md
+++ b/tests/testthat/_snaps/subscript-validation.md
@@ -1,4 +1,4 @@
-# x[a:b] guards against non-positive bounds at runtime
+# dynamic x[a:b] bounds compile without runtime bounds guards
 
     Code
       fn
@@ -11,16 +11,13 @@
     Code
       cat(fsub)
     Output
-      subroutine fn(x, n, out_, x__len_, quickr_err_msg) bind(c)
-        use iso_c_binding, only: c_char, c_double, c_int, c_null_char, c_ptrdiff_t
+      subroutine fn(x, n, out_, x__len_) bind(c)
+        use iso_c_binding, only: c_double, c_int, c_ptrdiff_t
         implicit none
       
         ! manifest start
         ! sizes
         integer(c_ptrdiff_t), intent(in), value :: x__len_
-      
-        ! error
-        character(kind=c_char), intent(inout) :: quickr_err_msg(256)
       
         ! args
         real(c_double), intent(in) :: x(x__len_)
@@ -29,23 +26,7 @@
         ! manifest end
       
       
-        if (n < 1_c_int) then
-          call quickr_set_error_msg("index ranges in x[a:b] must have bounds >= 1")
-          return
-        end if
         out_ = x(1_c_int:n:sign(1, n-1_c_int))
-      
-        contains
-          subroutine quickr_set_error_msg(msg)
-            character(len=*), intent(in) :: msg
-            integer :: i
-            integer :: n
-            if (quickr_err_msg(1) == c_null_char) then
-              n = min(len(msg), 256 - 1)
-              quickr_err_msg(1:n) = [(msg(i:i), i = 1, n)]
-              quickr_err_msg(n + 1) = c_null_char
-            end if
-          end subroutine quickr_set_error_msg
       end subroutine
     Code
       cat(cwrapper)
@@ -59,8 +40,7 @@
         const double* const x__, 
         const int* const n__, 
         double* const out___, 
-        const R_xlen_t x__len_, 
-        char* quickr_err_msg);
+        const R_xlen_t x__len_);
       
       SEXP fn_(SEXP _args) {
         // x
@@ -89,19 +69,11 @@
         SEXP out_ = PROTECT(Rf_allocVector(REALSXP, out___len_));
         double* out___ = REAL(out_);
         
-        char quickr_err_msg[256];
-        quickr_err_msg[0] = '\0';
-        
-        
         fn(
           x__,
           n__,
           out___,
-          x__len_,
-          quickr_err_msg);
-        if (quickr_err_msg[0] != '\0') {
-          Rf_error("%s", quickr_err_msg);
-        }
+          x__len_);
         
         UNPROTECT(1);
         return out_;

--- a/tests/testthat/test-for-iterables.R
+++ b/tests/testthat/test-for-iterables.R
@@ -288,3 +288,58 @@ test_that("for() supports rev() for value iteration", {
   expect_quick_identical(rev_values, 1:3, c(1L, 2L, 3L, 4L))
   expect_quick_identical(rev_matrix_values, matrix(1:6, nrow = 2))
 })
+
+test_that("unbraced for() bodies keep hoisted setup inside index loops", {
+  rolling_sum <- function(x, weights) {
+    declare(type(x = double(NA)), type(weights = double(NA)))
+    out <- double(length(x) - length(weights) + 1L)
+    n <- length(weights)
+    # fmt: skip
+    for (i in seq_along(out))
+      out[i] <- sum(x[i:(i + n - 1L)] * weights)
+    out
+  }
+
+  seq_lengths <- function(k) {
+    declare(type(k = integer(1)))
+    out <- 0L
+    # fmt: skip
+    for (i in 1:3)
+      out <- out + length(seq(i, i + 3L, by = k))
+    out
+  }
+
+  expect_quick_identical(
+    rolling_sum,
+    list(as.double(1:8), c(0.25, 0.75))
+  )
+  expect_quick_identical(seq_lengths, 1L, 2L)
+
+  qseq_lengths := quick(seq_lengths)
+  expect_error(
+    qseq_lengths(0L),
+    "invalid '(to - from)/by'",
+    fixed = TRUE
+  )
+  expect_error(
+    qseq_lengths(-1L),
+    "wrong sign in 'by' argument",
+    fixed = TRUE
+  )
+})
+
+test_that("unbraced for() bodies keep hoisted setup inside value loops", {
+  sum_floors <- function(starts) {
+    declare(type(starts = integer(NA)))
+    out <- 0
+    # fmt: skip
+    for (i in starts)
+      out <- out + floor(i + 0.5)
+    out
+  }
+
+  expect_quick_identical(
+    sum_floors,
+    c(1L, 3L, 5L)
+  )
+})

--- a/tests/testthat/test-onload.R
+++ b/tests/testthat/test-onload.R
@@ -1,0 +1,14 @@
+# Unit test for package-load side effects
+
+skip_on_cran()
+
+test_that("OMP_CANCELLATION is set on load when unset, respected when preset", {
+  withr::with_envvar(c(OMP_CANCELLATION = NA), {
+    quickr:::.onLoad()
+    expect_identical(Sys.getenv("OMP_CANCELLATION"), "true")
+  })
+  withr::with_envvar(c(OMP_CANCELLATION = "false"), {
+    quickr:::.onLoad()
+    expect_identical(Sys.getenv("OMP_CANCELLATION"), "false")
+  })
+})

--- a/tests/testthat/test-subscript-validation.R
+++ b/tests/testthat/test-subscript-validation.R
@@ -94,6 +94,20 @@ test_that("literal subscripts beyond a known extent are compile errors", {
   expect_no_error(quick(fna))
 })
 
+test_that("numeric literal subscripts are validated after integer coercion", {
+  ftruncate <- function(x) {
+    declare(type(x = double(3)))
+    x[3.9]
+  }
+  expect_quick_identical(ftruncate, list(as.double(1:3)))
+
+  fzero <- function(x) {
+    declare(type(x = double(3)))
+    x[0.5]
+  }
+  expect_error(quick(fzero), "subscripts must be positive")
+})
+
 test_that("assignment subscripts get the same validation as reads", {
   # x[-1L] <- 9 compiled into a silent out-of-bounds Fortran write
   fneg <- function(x) {
@@ -205,9 +219,36 @@ test_that("seq() value with a symbolic by is sized by the step", {
     declare(type(k = integer(1)))
     seq(1L, 9L, by = k)
   }
+  sum_fn <- function(k) {
+    declare(type(k = integer(1)))
+    sum(seq(1L, 9L, by = k))
+  }
+
   qfn := quick(fn)
+  qsum := quick(sum_fn)
   expect_identical(qfn(2L), seq(1L, 9L, by = 2L))
   expect_identical(qfn(4L), seq(1L, 9L, by = 4L))
+  expect_identical(qsum(2L), sum(seq(1L, 9L, by = 2L)))
+  expect_error(
+    qfn(0L),
+    "invalid '(to - from)/by'",
+    fixed = TRUE
+  )
+  expect_error(
+    qfn(-2L),
+    "wrong sign in 'by' argument",
+    fixed = TRUE
+  )
+  expect_error(
+    qsum(0L),
+    "invalid '(to - from)/by'",
+    fixed = TRUE
+  )
+  expect_error(
+    qsum(-2L),
+    "wrong sign in 'by' argument",
+    fixed = TRUE
+  )
 })
 
 test_that("x[seq_len(n)] with n = 0 returns a zero-length result like R", {

--- a/tests/testthat/test-subscript-validation.R
+++ b/tests/testthat/test-subscript-validation.R
@@ -1,5 +1,4 @@
-# Unit tests for subscript validation: negative/zero rejection and
-# runtime guards on index ranges
+# Unit tests for compile-time subscript validation and seq() step guards
 
 skip_on_cran()
 
@@ -168,16 +167,14 @@ test_that("assignment subscripts get the same validation as reads", {
   expect_quick_identical(fok, list(matrix(as.double(1:6), 2, 3)))
 })
 
-test_that("x[a:b] guards against non-positive bounds at runtime", {
+test_that("dynamic x[a:b] bounds compile without runtime bounds guards", {
   fn <- function(x, n) {
     declare(type(x = double(NA)), type(n = integer(1)))
     x[1:n]
   }
-  expect_translation_snapshots(fn) # pins the guard text
+  expect_translation_snapshots(fn) # pins the absence of a bounds guard
   qfn := quick(fn)
   expect_equal(qfn(as.double(1:5), 3L), c(1, 2, 3))
-  expect_error(qfn(as.double(1:5), 0L), "bounds >= 1")
-  expect_error(qfn(as.double(1:5), -2L), "bounds >= 1")
 
   # descending ranges still work
   fdesc <- function(x, n) {
@@ -186,7 +183,6 @@ test_that("x[a:b] guards against non-positive bounds at runtime", {
   }
   qdesc := quick(fdesc)
   expect_equal(qdesc(as.double(1:4), 4L), c(4, 3, 2, 1))
-  expect_error(qdesc(as.double(1:4), 0L), "bounds >= 1")
 })
 
 test_that("literal in-range bounds emit no guard; bad literals error at compile time", {
@@ -227,6 +223,16 @@ test_that("non-singleton x[seq(a, b, by)] validates the step", {
   qfs := quick(fs)
   expect_equal(qfs(as.double(1:9), 8L), c(5, 6, 7, 8))
   expect_error(qfs(as.double(1:9), 2L), "wrong sign")
+
+  # Scalar results do not need the sequence length in the C bridge, so the
+  # Fortran guard must continue to validate the step in this context.
+  fsum <- function(x, n) {
+    declare(type(x = double(NA)), type(n = integer(1)))
+    sum(x[seq(5L, n, by = 1L)])
+  }
+  qsum := quick(fsum)
+  expect_equal(qsum(as.double(1:9), 8L), sum(5:8))
+  expect_error(qsum(as.double(1:9), 2L), "wrong sign")
 })
 
 test_that("a singleton seq() subscript accepts a symbolic step", {

--- a/tests/testthat/test-subscript-validation.R
+++ b/tests/testthat/test-subscript-validation.R
@@ -41,6 +41,15 @@ test_that("negative and zero subscripts are rejected at compile time", {
   expect_error(quick(fnm), "negative subscripts|subscripts must be positive")
 })
 
+test_that("double negation remains a positive subscript", {
+  fn <- function(x) {
+    declare(type(x = double(4)))
+    x[-(-1L)]
+  }
+
+  expect_quick_identical(fn, list(as.double(1:4)))
+})
+
 test_that("literal subscripts beyond a known extent are compile errors", {
   # R pads out-of-range reads with NA; quickr refuses at compile time
   fn <- function(x) {
@@ -195,7 +204,7 @@ test_that("literal in-range bounds emit no guard; bad literals error at compile 
   expect_error(quick(fbad), "bounds >= 1")
 })
 
-test_that("x[seq(a, b, by)] requires a literal step and guards wrong signs", {
+test_that("non-singleton x[seq(a, b, by)] validates the step", {
   fdesc <- function(x) {
     declare(type(x = double(5)))
     x[seq(5L, 1L, by = -1L)]
@@ -218,6 +227,38 @@ test_that("x[seq(a, b, by)] requires a literal step and guards wrong signs", {
   qfs := quick(fs)
   expect_equal(qfs(as.double(1:9), 8L), c(5, 6, 7, 8))
   expect_error(qfs(as.double(1:9), 2L), "wrong sign")
+})
+
+test_that("a singleton seq() subscript accepts a symbolic step", {
+  fn <- function(x, n, k) {
+    declare(
+      type(x = double(5)),
+      type(n = integer(1)),
+      type(k = integer(1))
+    )
+    x[seq(n, n, by = k)]
+  }
+
+  expect_quick_identical(
+    fn,
+    list(as.double(1:5), 3L, 0L),
+    list(as.double(5:1), 3L, -2L)
+  )
+
+  fparen <- function(x, n, k) {
+    declare(
+      type(x = double(5)),
+      type(n = integer(1)),
+      type(k = integer(1))
+    )
+    x[seq(n, (n), by = k)]
+  }
+
+  expect_quick_identical(
+    fparen,
+    list(as.double(1:5), 3L, 0L),
+    list(as.double(5:1), 3L, -2L)
+  )
 })
 
 test_that("seq() value with a symbolic by is sized by the step", {

--- a/tests/testthat/test-subscript-validation.R
+++ b/tests/testthat/test-subscript-validation.R
@@ -1,0 +1,117 @@
+# Unit tests for subscript validation: negative/zero rejection and
+# runtime guards on index ranges
+
+skip_on_cran()
+
+test_that("negative and zero subscripts are rejected at compile time", {
+  fn <- function(x) {
+    declare(type(x = double(4)))
+    x[-1L]
+  }
+  expect_error(quick(fn), "negative subscripts|subscripts must be positive")
+
+  fn0 <- function(x) {
+    declare(type(x = double(4)))
+    x[0L]
+  }
+  expect_error(quick(fn0), "subscripts must be positive")
+
+  fni <- function(x, i) {
+    declare(type(x = double(4)), type(i = integer(1)))
+    x[-i]
+  }
+  expect_error(quick(fni), "negative subscripts")
+
+  fnr <- function(x) {
+    declare(type(x = double(4)))
+    x[-(1:2)]
+  }
+  expect_error(quick(fnr), "negative subscripts")
+
+  fnc <- function(x) {
+    declare(type(x = double(4)))
+    x[c(-1L, -2L)]
+  }
+  expect_error(quick(fnc), "negative subscripts|subscripts must be positive")
+
+  fnm <- function(x) {
+    declare(type(x = double(3, 3)))
+    x[1L, -2L]
+  }
+  expect_error(quick(fnm), "negative subscripts|subscripts must be positive")
+})
+
+test_that("x[a:b] guards against non-positive bounds at runtime", {
+  fn <- function(x, n) {
+    declare(type(x = double(NA)), type(n = integer(1)))
+    x[1:n]
+  }
+  expect_translation_snapshots(fn) # pins the guard text
+  qfn := quick(fn)
+  expect_equal(qfn(as.double(1:5), 3L), c(1, 2, 3))
+  expect_error(qfn(as.double(1:5), 0L), "bounds >= 1")
+  expect_error(qfn(as.double(1:5), -2L), "bounds >= 1")
+
+  # descending ranges still work
+  fdesc <- function(x, n) {
+    declare(type(x = double(NA)), type(n = integer(1)))
+    x[n:1]
+  }
+  qdesc := quick(fdesc)
+  expect_equal(qdesc(as.double(1:4), 4L), c(4, 3, 2, 1))
+  expect_error(qdesc(as.double(1:4), 0L), "bounds >= 1")
+})
+
+test_that("literal in-range bounds emit no guard; bad literals error at compile time", {
+  fn <- function(x) {
+    declare(type(x = double(5)))
+    x[2:4]
+  }
+  expect_translation_snapshots(fn) # pins the absence of a guard
+  expect_quick_identical(fn, list(as.double(1:5)))
+
+  fbad <- function(x) {
+    declare(type(x = double(5)))
+    x[0:2]
+  }
+  expect_error(quick(fbad), "bounds >= 1")
+})
+
+test_that("x[seq(a, b, by)] requires a literal step and guards wrong signs", {
+  # the result length divides by the step, and the C bridge evaluates it
+  # before any runtime guard could run -> compile error
+  fn <- function(x, k) {
+    declare(type(x = double(NA)), type(k = integer(1)))
+    x[seq(1L, 5L, by = k)]
+  }
+  expect_error(quick(fn), "literal `by`")
+
+  # literal step, symbolic bound: R errors on the wrong-sign case
+  fs <- function(x, n) {
+    declare(type(x = double(NA)), type(n = integer(1)))
+    x[seq(5L, n, by = 1L)]
+  }
+  qfs := quick(fs)
+  expect_equal(qfs(as.double(1:9), 8L), c(5, 6, 7, 8))
+  expect_error(qfs(as.double(1:9), 2L), "wrong sign")
+})
+
+test_that("seq() value with a symbolic by is sized by the step", {
+  fn <- function(k) {
+    declare(type(k = integer(1)))
+    seq(1L, 9L, by = k)
+  }
+  qfn := quick(fn)
+  expect_identical(qfn(2L), seq(1L, 9L, by = 2L))
+  expect_identical(qfn(4L), seq(1L, 9L, by = 4L))
+})
+
+test_that("x[seq_len(n)] with n = 0 returns a zero-length result like R", {
+  fn <- function(x, n) {
+    declare(type(x = double(NA)), type(n = integer(1)))
+    x[seq_len(n)]
+  }
+  qfn := quick(fn)
+  expect_equal(qfn(as.double(1:5), 3L), c(1, 2, 3))
+  expect_equal(qfn(as.double(1:5), 0L), double(0))
+})

--- a/tests/testthat/test-subscript-validation.R
+++ b/tests/testthat/test-subscript-validation.R
@@ -196,6 +196,12 @@ test_that("literal in-range bounds emit no guard; bad literals error at compile 
 })
 
 test_that("x[seq(a, b, by)] requires a literal step and guards wrong signs", {
+  fdesc <- function(x) {
+    declare(type(x = double(5)))
+    x[seq(5L, 1L, by = -1L)]
+  }
+  expect_quick_identical(fdesc, list(as.double(1:5)))
+
   # the result length divides by the step, and the C bridge evaluates it
   # before any runtime guard could run -> compile error
   fn <- function(x, k) {

--- a/tests/testthat/test-subscript-validation.R
+++ b/tests/testthat/test-subscript-validation.R
@@ -41,6 +41,110 @@ test_that("negative and zero subscripts are rejected at compile time", {
   expect_error(quick(fnm), "negative subscripts|subscripts must be positive")
 })
 
+test_that("literal subscripts beyond a known extent are compile errors", {
+  # R pads out-of-range reads with NA; quickr refuses at compile time
+  fn <- function(x) {
+    declare(type(x = double(3)))
+    x[4L]
+  }
+  expect_error(quick(fn), "exceeds its dimension's extent \\(3\\)")
+
+  frange <- function(x) {
+    declare(type(x = double(3)))
+    x[2:4]
+  }
+  expect_error(quick(frange), "exceeds its dimension's extent \\(3\\)")
+
+  fc <- function(x) {
+    declare(type(x = double(3)))
+    x[c(1L, 4L)]
+  }
+  expect_error(quick(fc), "exceeds its dimension's extent \\(3\\)")
+
+  fmat <- function(m) {
+    declare(type(m = double(2, 3)))
+    m[1L, 5L]
+  }
+  expect_error(quick(fmat), "exceeds its dimension's extent \\(3\\)")
+
+  # linear indexing on a matrix checks against the total size
+  flin <- function(m) {
+    declare(type(m = double(2, 3)))
+    m[7L]
+  }
+  expect_error(quick(flin), "exceeds its dimension's extent \\(6\\)")
+
+  # in-range literals and symbolic subscripts/extents are untouched
+  fok <- function(x) {
+    declare(type(x = double(3)))
+    x[3L] + x[1:3][1L]
+  }
+  expect_quick_identical(fok, list(as.double(1:3)))
+
+  fsym <- function(x, i) {
+    declare(type(x = double(3)), type(i = integer(1)))
+    x[i]
+  }
+  expect_no_error(quick(fsym))
+
+  fna <- function(x) {
+    declare(type(x = double(NA)))
+    x[5L]
+  }
+  expect_no_error(quick(fna))
+})
+
+test_that("assignment subscripts get the same validation as reads", {
+  # x[-1L] <- 9 compiled into a silent out-of-bounds Fortran write
+  fneg <- function(x) {
+    declare(type(x = double(3)))
+    x[-1L] <- 9
+    x
+  }
+  expect_error(quick(fneg), "subscripts must be positive")
+
+  fzero <- function(x) {
+    declare(type(x = double(3)))
+    x[0L] <- 1
+    x
+  }
+  expect_error(quick(fzero), "subscripts must be positive")
+
+  foob <- function(x) {
+    declare(type(x = double(3)))
+    x[4L] <- 1
+    x
+  }
+  expect_error(quick(foob), "exceeds its dimension's extent \\(3\\)")
+
+  fmat <- function(m) {
+    declare(type(m = double(2, 3)))
+    m[3L, 1L] <- 1
+    m
+  }
+  expect_error(quick(fmat), "exceeds its dimension's extent \\(2\\)")
+
+  # superassignment from a local closure shares the path
+  fsuper <- function(x) {
+    declare(type(x = double(3)))
+    bump <- function() {
+      x[4L] <<- 1
+    }
+    bump()
+    x
+  }
+  expect_error(quick(fsuper), "exceeds its dimension's extent \\(3\\)")
+
+  # valid writes still compile and match R
+  fok <- function(m) {
+    declare(type(m = double(2, 3)))
+    m[2L, 3L] <- 1
+    m[, 2L] <- 0
+    m
+  }
+  expect_quick_identical(fok, list(matrix(as.double(1:6), 2, 3)))
+})
+
 test_that("x[a:b] guards against non-positive bounds at runtime", {
   fn <- function(x, n) {
     declare(type(x = double(NA)), type(n = integer(1)))


### PR DESCRIPTION
> **Stacked PR 5 of 15** — branch `conformability/05-subscript-validation`,
> cut from PR 4 (#140), branch `conformability/04-ifelse-t-diag`.
> GitHub can only diff a fork branch against `main`, so until PR 4 merges
> this page also shows PRs 1–4's commits; the 5 commits new to *this*
> PR are `Move emit_quickr_error_if() to error-handling.R` … `Extract
> check_subscript_exprs() shared by read and write subscripts`.
>
> Stack overview and suggested review order: #152.

Fixes #126.

## What changed

**Negative and zero subscripts are now compile-time errors.** R's negative
subscript means exclusion and its zero subscript is silently dropped —
both produce result shapes that depend on the subscript's *value*, which
quickr's static-shape model cannot represent — and the generated Fortran
read out of bounds (`x(-1)`, `x(0)`) and returned the wrong shape:

```r
fn <- function(x) {
  declare(type(x = double(4)))
  x[-1L]
}
# before: silent out-of-bounds read, scalar result (R returns length 3)
# after:  Error: subscripts must be positive; R's negative (exclusion) and
#         zero subscripts are not supported: -1L
```

The syntactic form `x[-i]` is rejected too — unary minus on a subscript is
unambiguously exclusion in R, so the *form* is refused even when the value
is unknown (`negative subscripts (exclusion) are not supported: -i`). Same
for negative/zero elements of literal vectors (`x[c(-1L, -2L)]`) and
literal range bounds < 1 (`x[0:2]`).

**Assignment subscripts get the same validation.** `x[-1L] <- 9` and
`x[0L] <- 1` bypassed the read-side checks entirely and compiled into
silent out-of-bounds Fortran *writes*. `compile_subset_designator()` now
runs the same checks, covering `[<-`, `[<<-`, and closure host writes.

**Literal subscripts are checked against statically-known extents.**
`x[4L]` and `x[2:4]` on a declared `double(3)` compiled and read garbage
where R pads with NA (and grows the vector on writes) — neither
representable in quickr's static-shape model. When the base's extent
along an axis is a literal, out-of-range literal values, `:` endpoints,
and `c()` elements are now compile errors
(`subscript exceeds its dimension's extent (3): 4L; R's out-of-range
subscripts (NA padding, vector growing) are not supported`). A single subscript
on a rank>1 base (R's linear indexing) checks against the product of the
dims. Symbolic subscripts and symbolic extents are untouched — symbolic
scalar subscripts stay trusted-in-bounds (see notes).

**`x[a:b]` with runtime bounds gets a runtime guard.** The emitted section
`a:b:sign(1, b-a)` and its claimed length `abs(b-a)+1` are correct exactly
when both bounds are >= 1; `x[1:n]` with `n = 0` used to read `x(0)` and
return 2 values where R returns 1. Now a single scalar check per statement
runs before any memory is touched:

```fortran
if (n < 1_c_int) then
  call quickr_set_error_msg("index ranges in x[a:b] must have bounds >= 1")
  return
end if
out = x(1_c_int:n:sign(1, n-1_c_int))
```

Literal halves of the check are constant-folded away (`x[2:4]` emits no
guard), and descending ranges (`x[n:1]`) still work.

**`x[seq(a, b, by = step)]`**: a non-literal `step` is now a compile
error — the result length divides by the step and is evaluated in the
generated C bridge *before* any Fortran guard could run, so a zero step
was an unguardable division-by-zero crash. (It was also mis-sized:
`seq_like_length_expr()` silently dropped a non-literal `by`, so
`x[seq(1L, 9L, by = k)]` claimed length 9 for every `k`, returning garbage
past the real section; the same fix makes `seq(1L, 9L, by = k)` in value
position size correctly.) With a literal step and symbolic bounds, the
wrong-sign case gets a runtime guard raising "wrong sign in 'by'
argument", as R does.

`x[seq_len(n)]` / `x[seq_along(y)]` need no guard: their worst case is a
legal zero-length section, matching R's `x[integer(0)]` (covered by a new
test). For-loops are untouched — `do i = 1, 0` already runs zero times.

**Errors raised inside OpenMP loops now cancel the loop.** Generated
error paths emit `!$omp cancel do`, but per the OpenMP spec cancel
constructs are no-ops unless `OMP_CANCELLATION=true` is set when the
OpenMP runtime first initializes — and nothing set it. The error
*message* was recorded correctly, but every remaining iteration still
ran, and statements after a failed in-loop check kept executing in that
iteration's thread. quickr now sets `OMP_CANCELLATION=true` in `.onLoad`
when unset (a pre-set value is respected). Caveats documented in
`?declare`: no effect if another package already initialized the OpenMP
runtime, so early exit stays best-effort — messages are always correct
either way.

## How

- `emit_quickr_error_if()` moved from the BLAS translation file to
  `R/error-handling.R` (unchanged) so any handler can emit a statement-
  level runtime guard; this PR is the first non-BLAS consumer.
- `R/r2f-subscript.R`: new `check_subscript_exprs()` validates the raw R
  index expressions at the top of the `[` handler, where literalness and
  unary minus are still visible (per index, `check_subscript_expr()`
  handles literal values, unary minus, `:` endpoints, and recurses into
  `c()`); `subscript_axis_extents()` supplies the per-axis literal
  extents, and `compile_subset_designator()` (`R/r2f-closures.R`) calls
  the same `check_subscript_exprs()` for assignments.
- `R/r2f-iterables-helpers.R`: new `check_subscript_range_bounds()`
  called from `seq_like_r2f()`'s subscript branch; plus the
  `seq_like_length_expr()` fix (the literal-bounds fast path now requires
  a literal `by` too).
- `R/zzz.R`, `R/declare.R`: the `OMP_CANCELLATION` set-if-unset and its
  documentation.

## Tests

New `test-subscript-validation.R`: compile-time rejections for every
exclusion form; literal out-of-extent rejections for reads and writes
(scalar, range, `c()`, per-axis matrix, linear indexing, `[<<-`) with
in-range and symbolic cases still compiling; runtime guard firing for
`x[1:n]` (n = 0 and negative)
with the valid and descending cases still passing; no-guard translation
snapshot for literal bounds; the seq-step compile error and wrong-sign
runtime guard; zero-length `x[seq_len(0)]` matching R; symbolic-`by`
`seq()` sizing in value position. Translation snapshots pin the guard
text. New `test-onload.R` covers set-when-unset / respect-when-preset.

Snapshot churn: only `example-roll_mean.md` — its `x[i:(i + n - 1)]` now
carries the bounds guard inside the loop (plus the error-message plumbing
in the subroutine signature and C bridge).

## Notes for review

- Behavior changes (candidates for NEWS): `x[1:0]`-style empty ranges now
  raise an R error instead of reading out of bounds (R drops the 0 and
  returns `x[1]` — a value-dependent shape quickr cannot produce);
  exclusion subscripts that previously "worked" by reading garbage now
  fail to compile; `x[seq(a, b, by = k)]` with non-literal `k` now fails
  to compile (it previously returned garbage past the real section);
  literal out-of-extent subscripts (`x[4L]` on `double(3)`, reads and
  writes) now fail to compile instead of touching out-of-bounds memory.
- Scalar symbolic subscripts (`x[k]` where `k` might be <= 0 at run time)
  are deliberately *not* guarded per-element — they stay trusted to be
  positive and in bounds, as before this PR; a `quickr.bounds_check`
  option could add opt-in guards later.
- The guard inside `roll_mean`'s loop is two scalar compares per
  iteration next to a windowed `sum()`; hoisting loop-invariant guards
  out of loops is a possible future optimization, not attempted here.